### PR TITLE
Faster deserialization

### DIFF
--- a/hub/core/storage/lru_cache.py
+++ b/hub/core/storage/lru_cache.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Set, Union
 from hub.core.storage.provider import StorageProvider
 
 
-def _get_nbytes(obj: Union[bytes, memoryview, bytearray, Cachable]):
+def _get_nbytes(obj: Union[bytes, memoryview, Cachable]):
     if isinstance(obj, Cachable):
         return obj.nbytes
     return len(obj)
@@ -87,7 +87,7 @@ class LRUCache(StorageProvider):
                 )
             return item
 
-        if isinstance(item, (bytes, memoryview, bytearray)):
+        if isinstance(item, (bytes, memoryview)):
             obj = expected_class.frombuffer(item)
 
             if isinstance(obj, CachableCallback):


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

* Reduce copies



### Test script

```python
from hub.core.serialize import (
    serialize_chunk,
    deserialize_chunk,
)
import numpy as np
import hub
import time


# Dummy chunk data
version = hub.__version__
shape_info = np.cast[hub.constants.ENCODING_DTYPE](
    np.random.randint(100, size=(17, 63))
)
byte_positions = np.cast[hub.constants.ENCODING_DTYPE](
    np.random.randint(100, size=(31, 3))
)
data = [b"x" * 16 * 1024 * 1024]  # 16 MB chunk

# Serialize
encoded = serialize_chunk(version, shape_info, byte_positions, data)

# Deserialize
start = time.time()
for _ in range(10000):
    decoded = deserialize_chunk(encoded)
end = time.time()

print(f"{end - start} seconds.")

```

### Results:

`main`: 44.74688410758972 seconds.
`fr_fast_deserialize`: 0.031249046325683594 seconds

