### PR TITLE
Added coco_keypoint htype and changed default dtype for segment masks

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -459,6 +459,7 @@ def test_htype(memory_ds: Dataset):
     video = memory_ds.create_tensor("video", htype="video")
     bin_mask = memory_ds.create_tensor("bin_mask", htype="binary_mask")
     segment_mask = memory_ds.create_tensor("segment_mask", htype="segment_mask")
+    keypoint_coco = memory_ds.create_tensor("keypoint_coco", htype="keypoint_coco")
 
     image.append(np.ones((28, 28, 3), dtype=np.uint8))
     bbox.append(np.array([1.0, 1.0, 0.0, 0.5], dtype=np.float32))
@@ -466,7 +467,8 @@ def test_htype(memory_ds: Dataset):
     label.append(np.array(5, dtype=np.uint32))
     video.append(np.ones((10, 28, 28, 3), dtype=np.uint8))
     bin_mask.append(np.zeros((28, 28), dtype=np.bool8))
-    segment_mask.append(np.ones((28, 28), dtype=np.int32))
+    segment_mask.append(np.ones((28, 28), dtype=np.uint32))
+    keypoint_coco.append(np.ones((51, 2), dtype=np.float32))
 
 
 def test_dtype(memory_ds: Dataset):
@@ -701,6 +703,7 @@ def test_htypes_list():
         "generic",
         "image",
         "json",
+        "keypoint_coco",
         "list",
         "segment_mask",
         "text",

--- a/hub/htype.py
+++ b/hub/htype.py
@@ -26,7 +26,7 @@ Supported htypes and their respective defaults are:
 | video         |  uint8    |  none         |
 | binary_mask   |  bool     |  none         |
 | segment_mask  |  int32    |  none         |
-| coco_keypoint |  int32    |  none         |
+| keypoint_coco |  int32    |  none         |
 
 """
 
@@ -58,7 +58,7 @@ HTYPE_CONFIGURATIONS: Dict[str, Dict] = {
         "dtype": "bool"
     },  # TODO: pack numpy arrays to store bools as 1 bit instead of 1 byte
     "segment_mask": {"dtype": "uint32"},
-    "coco_keypoint": {"dtype": "float32"},
+    "keypoint_coco": {"dtype": "float32"},
     "json": {
         "dtype": "Any",
     },


### PR DESCRIPTION
… to uint21

## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->