### PR TITLE
Add pytest fixture decorator to test_gcs_tokens

### DIFF
--- a/hub/core/storage/tests/test_storage_provider.py
+++ b/hub/core/storage/tests/test_storage_provider.py
@@ -1,12 +1,13 @@
 import json
 from hub.tests.path_fixtures import gcs_creds
+from hub.tests.common import is_opt_true
 from hub.tests.storage_fixtures import enabled_storages, enabled_persistent_storages
 from hub.tests.cache_fixtures import enabled_cache_chains
 from hub.core.storage.gcs import GCloudCredentials
 from hub.util.exceptions import GCSDefaultCredsNotFoundError
 import os
 import pytest
-from hub.constants import MB
+from hub.constants import MB, GCS_OPT
 import pickle
 
 
@@ -139,7 +140,11 @@ def test_pickling(storage):
     assert unpickled_storage[FILE_1] == b"hello world"
 
 
-def test_gcs_tokens():
+@pytest.fixture
+def test_gcs_tokens(request):
+    if not is_opt_true(request, GCS_OPT):
+        pytest.skip()
+        return
     gcreds = GCloudCredentials()
     assert gcreds.credentials
     token_path = os.environ["GOOGLE_APPLICATION_CREDENTIALS"]


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [X]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [X]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [X]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->
This PR adds a pytest fixture to `core/storage/tests/test_storage_provider.py` such that this test runs only when the `--gcs` option is passed to pytest.