### PR TITLE
Adds an exits staticmethod to the api.dataset class. Closes #1182.

### DIFF
--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -166,6 +166,9 @@ class dataset:
         Returns:
             Boolean to indicate if dataset exists.
         """
+        if creds is None:
+            creds = {}
+
         storage, cache_chain = get_storage_and_cache_chain(
             path=path,
             read_only=False,

--- a/hub/api/tests/test_dataset.py
+++ b/hub/api/tests/test_dataset.py
@@ -65,3 +65,14 @@ def test_update_privacy(hub_cloud_ds):
     assert not hub_cloud_ds.public
     with pytest.raises(hub.util.exceptions.AuthorizationException):
         hub.load(hub_cloud_ds.path)
+
+
+def test_dataset_exists():
+    with CliRunner().isolated_filesystem():
+        path = "test_dataset_exists"
+
+        assert hub.exits(path) is False
+
+        ds = hub.empty(path)
+
+        assert hub.exists(path) is True


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [X]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [X]  I have commented my code, particularly in hard-to-understand areas
- [X]  I have kept the `coverage-rate` up
- [X]  I have performed a self-review of my own code and resolved any problems
- [X]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [X]  I have described and made corresponding changes to the relevant documentation
- [X]  New and existing unit tests pass locally with my changes


### Changes

Implements the hub.exits method as described in #1182. 