### PR TITLE
[BUGFIX] Stream video only if chunk size is greater than max_chunk_size

### DIFF
--- a/hub/core/chunk_engine.py
+++ b/hub/core/chunk_engine.py
@@ -538,7 +538,7 @@ class ChunkEngine:
         stream = False
         if isinstance(base_storage, (S3Provider, GCSProvider)):
             chunk_size = base_storage.get_object_size(chunk_key)
-            stream = chunk_size > self.min_chunk_size
+            stream = chunk_size > self.max_chunk_size
             if stream:
                 chunk = self.cache.get_hub_object(
                     chunk_key, self.chunk_class, meta=self.chunk_args, url=True

--- a/hub/core/serialize.py
+++ b/hub/core/serialize.py
@@ -156,8 +156,6 @@ def get_header_from_url(url: str):
     shape_info_nbytes = shape_info_nrows * shape_info_ncols * itemsize
     offset += 8
 
-    while len(byts) - offset < shape_info_nbytes + 4:
-        byts += urlopen(request).read()
     if shape_info_nbytes == 0:
         shape_info = np.array([], dtype=enc_dtype)
     else:
@@ -172,8 +170,6 @@ def get_header_from_url(url: str):
     byte_positions_nbytes = byte_positions_rows * 3 * itemsize
     offset += 4
 
-    while len(byts) - offset < byte_positions_nbytes:
-        byts += urlopen(request).read()
     if byte_positions_nbytes == 0:
         byte_positions = np.array([], dtype=enc_dtype)
     else:

--- a/hub/core/serialize.py
+++ b/hub/core/serialize.py
@@ -143,7 +143,7 @@ def get_header_from_url(url: str):
     enc_dtype = np.dtype(hub.constants.ENCODING_DTYPE)
     itemsize = enc_dtype.itemsize
 
-    headers = {"Range": "bytes=0-100"}
+    headers = {"Range": "bytes=0-99"}
 
     request = Request(url, None, headers)
     byts = urlopen(request).read()
@@ -156,6 +156,8 @@ def get_header_from_url(url: str):
     shape_info_nbytes = shape_info_nrows * shape_info_ncols * itemsize
     offset += 8
 
+    while len(byts) - offset < shape_info_nbytes + 4:
+        byts += urlopen(request).read()
     if shape_info_nbytes == 0:
         shape_info = np.array([], dtype=enc_dtype)
     else:
@@ -170,6 +172,8 @@ def get_header_from_url(url: str):
     byte_positions_nbytes = byte_positions_rows * 3 * itemsize
     offset += 4
 
+    while len(byts) - offset < byte_positions_nbytes:
+        byts += urlopen(request).read()
     if byte_positions_nbytes == 0:
         byte_positions = np.array([], dtype=enc_dtype)
     else:


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
Get more header bytes if enough bytes were not fetched at first in `get_header_from_url`
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->