### PR TITLE
Do not hide S3 access errors

### DIFF
--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -2151,6 +2151,26 @@ class Dataset:
         self.storage.autoflush = autoflush
         return ds
 
+    @property
+    def no_view_dataset(self):
+        """Returns the same dataset without slicing."""
+        if self.index is None or self.index.is_trivial():
+            return self
+        return self.__class__(
+            storage=self.storage,
+            index=None,
+            group_index=self.group_index,
+            read_only=self.read_only,
+            public=self.public,
+            token=self._token,
+            verbose=False,
+            version_state=self.version_state,
+            path=self.path,
+            link_creds=self.link_creds,
+            pad_tensors=self._pad_tensors,
+            enabled_tensors=self.enabled_tensors,
+        )
+
     def _create_group(self, name: str) -> "Dataset":
         """Internal method used by `create_group` and `create_tensor`."""
         meta: DatasetMeta = self.version_state["meta"]

--- a/deeplake/enterprise/dataloader.py
+++ b/deeplake/enterprise/dataloader.py
@@ -113,8 +113,6 @@ class DeepLakeDataLoader:
             ValueError: If .shuffle() has already been called.
             ValueError: If dataset is view and shuffle is True
         """
-        if shuffle and isinstance(self.dataset.index.values[0].value, tuple):
-            raise ValueError("Can't shuffle dataset view")
         if self._shuffle is not None:
             raise ValueError("shuffle is already set")
         all_vars = self.__dict__.copy()
@@ -123,7 +121,8 @@ class DeepLakeDataLoader:
         if shuffle:
             schedule = create_fetching_schedule(self.dataset, self._primary_tensor_name)
             if schedule is not None:
-                all_vars["dataset"] = self.dataset[schedule]
+                ds = self.dataset.no_view_dataset
+                all_vars["dataset"] = ds[schedule]
         return self.__class__(**all_vars)
 
     def transform(

--- a/deeplake/integrations/tf/datasettotensorflow.py
+++ b/deeplake/integrations/tf/datasettotensorflow.py
@@ -35,24 +35,24 @@ def dataset_to_tensorflow(dataset, tensors, tobytes, fetch_chunks=True):
         tobytes = {k: k in tobytes for k in tensors}
 
     def __iter__():
-        for index in range(len(dataset)):
-            sample = {}
+        for sample in dataset:
+            out = {}
             corrupt_sample_found = False
             for key in tensors:
                 try:
-                    value = dataset[key][index]
+                    value = sample[key]
                     if tobytes[key]:
                         value = [value.tobytes()]
                     else:
                         value = value.numpy(fetch_chunks=fetch_chunks)
-                    sample[key] = value
+                    out[key] = value
                 except SampleDecompressionError:
                     warnings.warn(
                         f"Skipping corrupt {dataset[key].meta.sample_compression} sample."
                     )
                     corrupt_sample_found = True
             if not corrupt_sample_found:
-                yield sample
+                yield out
 
     def generate_signature():
         signature = {}

--- a/deeplake/util/exceptions.py
+++ b/deeplake/util/exceptions.py
@@ -342,6 +342,10 @@ class S3ListError(S3Error):
     """Catchall for all errors encountered while retrieving a list of objects present in S3"""
 
 
+class S3GetAccessError(S3GetError):
+    """Credentials related errors encountered while getting an object from S3"""
+
+
 class CompressionError(Exception):
     pass
 

--- a/deeplake/util/keys.py
+++ b/deeplake/util/keys.py
@@ -22,7 +22,11 @@ from deeplake.constants import (
     QUERIES_FILENAME,
     QUERIES_LOCK_FILENAME,
 )
-from deeplake.util.exceptions import S3GetError
+from deeplake.util.exceptions import (
+    S3GetError,
+    S3GetAccessError,
+    AuthorizationException,
+)
 
 
 def get_chunk_key(key: str, chunk_name: str, commit_id: str) -> str:
@@ -173,7 +177,9 @@ def dataset_exists(storage) -> bool:
     try:
         storage[get_dataset_meta_key(FIRST_COMMIT_ID)]
         return True
-    except (KeyError, S3GetError):
+    except S3GetAccessError as err:
+        raise AuthorizationException("The dataset storage cannot be accessed") from err
+    except (KeyError, S3GetError) as err:
         return False
 
 


### PR DESCRIPTION
If e.g. the wrong AWS profile is used the download of the open datasets which are stored in S3 will fail. These errors was completely hidden and was instead displayed as if the dataset does not exists, e.g.:
```
hub.util.exceptions.DatasetHandlerError: A Hub dataset does not exist at the given path (hub://activeloop/mnist-train). Check the path provided or in case you want to create a new dataset, use hub.empty().
```
This commit creates a new excpetion type which is not excepted to make it clear that it is an AWS S3 access error that is the cause.

## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

This commit makes the error messages more useful for debugging. E.g, consider a user who has a default region setup for AWS:

```
#~/.aws/config
[default]
region: eu-north-1
```
When the user wants to try out hub they do:
```bash
python -c "import hub; hub.load('hub://activeloop/mnist-train')"

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/daniel/src/Hub/hub/api/dataset.py", line 407, in load
    raise DatasetHandlerError(
hub.util.exceptions.DatasetHandlerError: A Hub dataset does not exist at the given path (hub://activeloop/mnist-train). Check the path provided or in case you want to create a new dataset, use hub.empty().
```

The error message states that the dataset does not exist, this is really confusing for someone who has not used Hub before.

After this change the error will instead be:
```bash
python -c "import hub; hub.load('hub://activeloop/mnist-train')"

Traceback (most recent call last):                                                                                                           
  File "/home/daniel/src/Hub/hub/core/storage/s3.py", line 251, in get_bytes
    return self._get_bytes(path, start_byte, end_byte)               
  File "/home/daniel/src/Hub/hub/core/storage/s3.py", line 224, in _get_bytes
    resp = self.client.get_object(Bucket=self.bucket, Key=path, Range=range)
  File "/home/daniel/workspace/shared_source/tflite-deep-learning-axis-camera/venv/lib/python3.10/site-packages/botocore/client.py", line 386, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/daniel/workspace/shared_source/tflite-deep-learning-axis-camera/venv/lib/python3.10/site-packages/botocore/client.py", line 705, in _make_api_call
    raise error_class(parsed_response, operation_name)                                                                                       
botocore.exceptions.ClientError: An error occurred (InvalidAccessKeyId) when calling the GetObject operation: The AWS Access Key Id you provided does not exist in our records.
                                                                      
During handling of the above exception, another exception occurred:                                                                                                                                                                                                                       
                                                                      
Traceback (most recent call last):
  File "/home/daniel/src/Hub/hub/core/storage/s3.py", line 262, in get_bytes                                                                                                                                                                                                              
    return self._get_bytes(path, start_byte, end_byte)                                                                                       
  File "/home/daniel/src/Hub/hub/core/storage/s3.py", line 224, in _get_bytes                                                                                                                                                                                                             
    resp = self.client.get_object(Bucket=self.bucket, Key=path, Range=range)
  File "/home/daniel/workspace/shared_source/tflite-deep-learning-axis-camera/venv/lib/python3.10/site-packages/botocore/client.py", line 386, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/daniel/workspace/shared_source/tflite-deep-learning-axis-camera/venv/lib/python3.10/site-packages/botocore/client.py", line 705, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidAccessKeyId) when calling the GetObject operation: The AWS Access Key Id you provided does not exist in our records.
                                                                      
During handling of the above exception, another exception occurred:
                                                                                                                                                                                                                                                                                          
Traceback (most recent call last):                                                                                                                                                                                                                                                        
  File "/home/daniel/src/Hub/hub/util/keys.py", line 174, in dataset_exists
    storage[get_dataset_meta_key(FIRST_COMMIT_ID)]
  File "/home/daniel/src/Hub/hub/core/storage/lru_cache.py", line 189, in __getitem__
    result = self.next_storage[path]
  File "/home/daniel/src/Hub/hub/core/storage/s3.py", line 211, in __getitem__
    return self.get_bytes(path)
  File "/home/daniel/src/Hub/hub/core/storage/s3.py", line 261, in get_bytes
    with manager(self, new_error_cls):  # type: ignore
  File "/home/daniel/src/Hub/hub/core/storage/s3.py", line 77, in __exit__
    raise self.error_class(exc_value).with_traceback(exc_traceback)
  File "/home/daniel/src/Hub/hub/core/storage/s3.py", line 262, in get_bytes
    return self._get_bytes(path, start_byte, end_byte)
  File "/home/daniel/src/Hub/hub/core/storage/s3.py", line 224, in _get_bytes
    resp = self.client.get_object(Bucket=self.bucket, Key=path, Range=range)
  File "/home/daniel/workspace/shared_source/tflite-deep-learning-axis-camera/venv/lib/python3.10/site-packages/botocore/client.py", line 386, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/daniel/workspace/shared_source/tflite-deep-learning-axis-camera/venv/lib/python3.10/site-packages/botocore/client.py", line 705, in _make_api_call
    raise error_class(parsed_response, operation_name)
hub.util.exceptions.S3GetAccessError: An error occurred (InvalidAccessKeyId) when calling the GetObject operation: The AWS Access Key Id you provided does not exist in our records.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/daniel/src/Hub/hub/api/dataset.py", line 406, in load
    if not dataset_exists(cache_chain):
  File "/home/daniel/src/Hub/hub/util/keys.py", line 177, in dataset_exists
    raise AuthorizationException("The dataset storage cannot be accessed") from err
hub.util.exceptions.AuthorizationException: The dataset storage cannot be accessed
```