### PR TITLE
Allow tensorflow dataset to fetch chunks

### DIFF
--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -1608,6 +1608,7 @@ class Dataset:
         self,
         tensors: Optional[Sequence[str]] = None,
         tobytes: Union[bool, Sequence[str]] = False,
+        fetch_chunks: bool = True,
     ):
         """Converts the dataset into a tensorflow compatible format.
 
@@ -1616,12 +1617,15 @@ class Dataset:
         Args:
             tensors (List, Optional): Optionally provide a list of tensor names in the ordering that your training script expects. For example, if you have a dataset that has "image" and "label" tensors, if ``tensors=["image", "label"]``, your training script should expect each batch will be provided as a tuple of (image, label).
             tobytes (bool): If ``True``, samples will not be decompressed and their raw bytes will be returned instead of numpy arrays. Can also be a list of tensors, in which case those tensors alone will not be decompressed.
+            fetch_chunks: See fetch_chunks argument in deeplake.core.tensor.Tensor.numpy()
 
         Returns:
             tf.data.Dataset object that can be used for tensorflow training.
         """
         dataset_read(self)
-        return dataset_to_tensorflow(self, tensors=tensors, tobytes=tobytes)
+        return dataset_to_tensorflow(
+            self, tensors=tensors, tobytes=tobytes, fetch_chunks=fetch_chunks
+        )
 
     def flush(self):
         """Necessary operation after writes if caches are being used.

--- a/deeplake/integrations/tf/datasettotensorflow.py
+++ b/deeplake/integrations/tf/datasettotensorflow.py
@@ -11,7 +11,7 @@ from deeplake.util.exceptions import (
 from deeplake.util.check_installation import tensorflow_installed
 
 
-def dataset_to_tensorflow(dataset, tensors, tobytes):
+def dataset_to_tensorflow(dataset, tensors, tobytes, fetch_chunks=True):
     """Converts the dataset into a tensorflow compatible format"""
     if not tensorflow_installed():
         raise ModuleNotInstalledException(
@@ -44,7 +44,7 @@ def dataset_to_tensorflow(dataset, tensors, tobytes):
                     if tobytes[key]:
                         value = [value.tobytes()]
                     else:
-                        value = value.numpy()
+                        value = value.numpy(fetch_chunks=fetch_chunks)
                     sample[key] = value
                 except SampleDecompressionError:
                     warnings.warn(


### PR DESCRIPTION
As described in #1885  iterating a small dataset with `ds.tensorflow()` is very slow.

If using the tensorflow dataset on a hub dataset which consist of multiple samples with small size, the iteration becomes considerably faster if using fetch_chunks=True when getting the data. This commit adds the ability to pass that option when creating the tensorflow dataset from the hub dataset.

On an MNIST dataset the result is 25 times faster iteration.

Benchmark can be found here:
https://gist.github.com/daniel-falk/188b96013e9f0cedcf555a0a30fa177d

TF chunks: 957 frames / second
TF current: 26 frames / second
Hub chunks: 1294 frames / second
Hub per sample: 28 frames / second 

## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes