### PR TITLE
[DL-763] Locking fix

### DIFF
--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -231,7 +231,7 @@ class Dataset:
         self.read_only = True
         if self.verbose:
             always_warn(
-                "Unable to update dataset lock as another machine has locked it for writing. Switching to read only mode."
+                "Unable to update dataset lock as another machine has locked it for writing or deleted / overwriten it. Switching to read only mode."
             )
         self._locked_out = True
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

Lock file was being written by the previous machine when a dataset is overwritten by another machine.

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->