### PR TITLE
[DL-782] Delete temp tensors in case append fails during transforms

### DIFF
--- a/deeplake/api/tests/test_api.py
+++ b/deeplake/api/tests/test_api.py
@@ -2026,6 +2026,7 @@ def test_transform_upload_fail(local_ds_generator, num_workers):
         np.testing.assert_array_equal(
             ds.labels.numpy().flatten(), np.array([0, 1, 2, 3])
         )
+         assert list(ds.tensors) == ["images", "labels"]
 
 
 def test_empty_sample_partial_read(s3_ds):

--- a/deeplake/api/tests/test_api.py
+++ b/deeplake/api/tests/test_api.py
@@ -1132,6 +1132,7 @@ def test_tensor_delete(local_ds_generator):
     ds.delete_group("x")
     assert list(ds.storage.keys()) == ["dataset_meta.json"]
     assert ds.tensors == {}
+    assert ds.meta.hidden_tensors == []
 
 
 def test_group_delete_bug(local_ds_generator):
@@ -2027,6 +2028,17 @@ def test_transform_upload_fail(local_ds_generator, num_workers):
             ds.labels.numpy().flatten(), np.array([0, 1, 2, 3])
         )
         assert list(ds.tensors) == ["images", "labels"]
+
+
+def test_ignore_temp_tensors(local_ds_generator):
+    with local_ds_generator() as ds:
+        ds.create_tensor("__temptensor")
+        ds.__temptensor.append(123)
+
+    with local_ds_generator() as ds:
+        assert list(ds.tensors) == []
+        assert ds.meta.hidden_tensors == []
+        assert list(ds.storage.keys()) == ["dataset_meta.json"]
 
 
 def test_empty_sample_partial_read(s3_ds):

--- a/deeplake/api/tests/test_api.py
+++ b/deeplake/api/tests/test_api.py
@@ -2026,7 +2026,7 @@ def test_transform_upload_fail(local_ds_generator, num_workers):
         np.testing.assert_array_equal(
             ds.labels.numpy().flatten(), np.array([0, 1, 2, 3])
         )
-         assert list(ds.tensors) == ["images", "labels"]
+        assert list(ds.tensors) == ["images", "labels"]
 
 
 def test_empty_sample_partial_read(s3_ds):

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -209,6 +209,7 @@ class Dataset:
         d["_parent_dataset"] = None
         d["_pad_tensors"] = pad_tensors
         d["_locking_enabled"] = lock
+        d["_temp_tensors"] = []
         dct = self.__dict__
         dct.update(d)
         dct["enabled_tensors"] = (
@@ -231,6 +232,9 @@ class Dataset:
             bool
         ] = []  # This is a stack to support nested with contexts
         self._indexing_history: List[int] = []
+
+        for temp_tensor in self._temp_tensors:
+            self.delete_tensor(temp_tensor)
 
     def _lock_lost_handler(self):
         """This is called when lock is acquired but lost later on due to slow update."""

--- a/deeplake/core/meta/dataset_meta.py
+++ b/deeplake/core/meta/dataset_meta.py
@@ -65,6 +65,10 @@ class DatasetMeta(Meta):
         """Reflect tensor deletion in dataset's meta."""
         key = self.tensor_names.pop(name)
         self.tensors.remove(key)
+        try:
+            self.hidden_tensors.remove(key)
+        except ValueError:
+            pass
         self.is_dirty = True
 
     def delete_group(self, name):

--- a/deeplake/core/transform/transform.py
+++ b/deeplake/core/transform/transform.py
@@ -248,7 +248,7 @@ class Pipeline:
         )
 
         for tensor in class_label_tensors:
-            temp_tensor = f"_{tensor}_{uuid4().hex[:4]}"
+            temp_tensor = f"__temp{tensor}_{uuid4().hex[:4]}"
             with target_ds:
                 temp_tensor_obj = target_ds.create_tensor(
                     temp_tensor,

--- a/deeplake/core/transform/transform.py
+++ b/deeplake/core/transform/transform.py
@@ -288,16 +288,22 @@ class Pipeline:
         )
         map_inp = zip(slices, storages, repeat(args))
 
-        if progressbar:
-            desc = get_pbar_description(self.functions)
-            result = compute.map_with_progressbar(
-                store_data_slice_with_pbar,
-                map_inp,
-                total_length=len(data_in),
-                desc=desc,
-            )
-        else:
-            result = compute.map(store_data_slice, map_inp)
+        try:
+            if progressbar:
+                desc = get_pbar_description(self.functions)
+                result = compute.map_with_progressbar(
+                    store_data_slice_with_pbar,
+                    map_inp,
+                    total_length=len(data_in),
+                    desc=desc,
+                )
+            else:
+                result = compute.map(store_data_slice, map_inp)
+        except Exception as e:
+            for tensor in label_temp_tensors.values():
+                target_ds.delete_tensor(tensor)
+            raise e
+
         result = process_transform_result(result)
 
         all_num_samples, all_tensors_generated_length = get_lengths_generated(

--- a/deeplake/util/version_control.py
+++ b/deeplake/util/version_control.py
@@ -539,6 +539,8 @@ def load_meta(dataset):
     _tensor_names.update(meta.tensor_names)
 
     for tensor_key in _tensor_names.values():
+        if tensor_key.startswith("__temp"):
+            dataset._temp_tensors.append(tensor_key)
         _tensors[tensor_key] = Tensor(tensor_key, dataset)
 
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
- prefix temporary tensors with `__temp`
- such tensors will be discarded (if they were not removed) during the next dataset load
- prevents dataset corruption
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->