### PR TITLE
Fix region issue with activeloop storage datasets

### DIFF
--- a/deeplake/client/client.py
+++ b/deeplake/client/client.py
@@ -243,8 +243,7 @@ class DeepLakeBackendClient:
             raise
         full_url = response.get("path")
         creds = response["creds"]
-        region = creds.pop("region", None)
-        creds["aws_region"] = region
+        creds["aws_region"] = creds.pop("region", None)
         mode = response["mode"]
         expiration = creds["expiration"]
         return full_url, creds, mode, expiration

--- a/deeplake/client/client.py
+++ b/deeplake/client/client.py
@@ -241,9 +241,10 @@ class DeepLakeBackendClient:
                         raise UserNotLoggedInException()
                     raise TokenPermissionError()
             raise
-
         full_url = response.get("path")
         creds = response["creds"]
+        region = creds.pop("region", None)
+        creds["aws_region"] = region
         mode = response["mode"]
         expiration = creds["expiration"]
         return full_url, creds, mode, expiration

--- a/deeplake/client/client.py
+++ b/deeplake/client/client.py
@@ -243,7 +243,6 @@ class DeepLakeBackendClient:
             raise
         full_url = response.get("path")
         creds = response["creds"]
-        creds["aws_region"] = creds.pop("region", None)
         mode = response["mode"]
         expiration = creds["expiration"]
         return full_url, creds, mode, expiration

--- a/deeplake/util/storage.py
+++ b/deeplake/util/storage.py
@@ -53,7 +53,7 @@ def storage_provider_from_path(
         secret = creds.get("aws_secret_access_key")
         session_token = creds.get("aws_session_token")
         endpoint_url = creds.get("endpoint_url")
-        region = creds.get("aws_region")
+        region = creds.get("aws_region") or creds.get("region")
         profile = creds.get("profile_name")
         storage: StorageProvider = S3Provider(
             path,


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

Region returned from backend wasn't being used while creating s3 provider