### PR TITLE
fix read for wav compressed audio

### DIFF
--- a/deeplake/core/compression.py
+++ b/deeplake/core/compression.py
@@ -429,7 +429,7 @@ def verify_compressed_file(
         elif compression == "jpeg":
             return _verify_jpeg(file), "|u1"
         elif get_compression_type(compression) == AUDIO_COMPRESSION:
-            return _read_audio_shape(file, compression), "<f4"  # type: ignore
+            return _read_audio_shape(file), "<f4"  # type: ignore
         elif compression in ("mp4", "mkv", "avi"):
             if isinstance(file, (bytes, memoryview, str)):
                 return _read_video_shape(file), "|u1"  # type: ignore


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

When calling 
```
deeplake.read("sample.wav", verify=True, compression="wav")
```

current code breaks as `_read_audio_shape` Is called with two arguments. 
Not sure why "compression" argument was passed - perhaps API changed at some point