### PR TITLE
[AL-1999] [Bug fix] lnfo not being updated after using Deep Lake compute on dataset.

### DIFF
--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -3214,8 +3214,6 @@ class Dataset:
             create_commit_chunk_sets(dest_id, storage, version_state)
             self.checkout(dest_id)
         load_meta(self)
-        self._info = None
-        self._ds_diff = None
 
     def _delete_metas(self):
         """Deletes all metas in the dataset."""

--- a/deeplake/core/transform/test_transform.py
+++ b/deeplake/core/transform/test_transform.py
@@ -126,6 +126,10 @@ def add_images(i, sample_out):
         image = deeplake.read(get_dummy_data_path("images/flower.png"))
         sample_out.append({"image": image})
 
+@deeplake.compute
+def small_transform(sample_in, samples_out):
+    samples_out.image.append(sample_in)
+
 
 def check_target_array(ds, index, target):
     np.testing.assert_array_equal(
@@ -1019,3 +1023,14 @@ def test_tensor_dataset_memory_leak(local_ds):
 
     n = retrieve_objects_from_memory()
     assert n == 0
+
+def test_transform_info(local_ds_generator):
+    ds = local_ds_generator()
+    with ds:
+        ds.create_tensor("image")
+        small_transform().eval(range(1), ds)
+        ds.info["test"] = 123
+        assert ds.info["test"] == 123
+    ds = local_ds_generator()
+    assert ds.info["test"] == 123
+    

--- a/deeplake/core/transform/test_transform.py
+++ b/deeplake/core/transform/test_transform.py
@@ -126,6 +126,7 @@ def add_images(i, sample_out):
         image = deeplake.read(get_dummy_data_path("images/flower.png"))
         sample_out.append({"image": image})
 
+
 @deeplake.compute
 def small_transform(sample_in, samples_out):
     samples_out.image.append(sample_in)
@@ -1024,6 +1025,7 @@ def test_tensor_dataset_memory_leak(local_ds):
     n = retrieve_objects_from_memory()
     assert n == 0
 
+
 def test_transform_info(local_ds_generator):
     ds = local_ds_generator()
     with ds:
@@ -1033,4 +1035,3 @@ def test_transform_info(local_ds_generator):
         assert ds.info["test"] == 123
     ds = local_ds_generator()
     assert ds.info["test"] == 123
-    

--- a/deeplake/util/version_control.py
+++ b/deeplake/util/version_control.py
@@ -523,6 +523,8 @@ def load_meta(dataset):
     version_state = dataset.version_state
     storage: LRUCache = dataset.storage
     storage.clear_deeplake_objects()
+    dataset._info = None
+    dataset._ds_diff = None
     meta_key = get_dataset_meta_key(version_state["commit_id"])
     meta = storage.get_deeplake_object(meta_key, DatasetMeta)
     if not meta.tensor_names:  # backward compatibility


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
The problem:-
- Dataset info object was being cleared from cache but not from dataset object, so changes were being made only to the in memory object and didn't persist in the actual storage.

The solution:-
- Reference to info and dataset diff are cleared from dataset object when cleared from cache. 
- On using these objects they are added back to the cache and are properly tracked.