### PR TITLE
[CUS-32] Fix dataloader behaviour for json and list tensors

### DIFF
--- a/deeplake/integrations/pytorch/common.py
+++ b/deeplake/integrations/pytorch/common.py
@@ -3,6 +3,7 @@ from deeplake.util.exceptions import EmptyTensorError
 from deeplake.util.iterable_ordered_dict import IterableOrderedDict
 from deeplake.core.polygon import Polygons
 import numpy as np
+import warnings
 
 
 def collate_fn(batch):
@@ -58,6 +59,7 @@ class PytorchTransformFunction:
 
 def check_tensors(dataset, tensors):
     compressed_tensors = []
+    json_list_tensors = []
     supported_compressions = {"png", "jpeg"}
     for tensor_name in tensors:
         tensor = dataset._get_tensor_from_root(tensor_name)
@@ -69,6 +71,14 @@ def check_tensors(dataset, tensors):
             )
         if tensor.meta.sample_compression in supported_compressions:
             compressed_tensors.append(tensor_name)
+        if tensor.meta.htype in {"list", "json"}:
+            json_list_tensors.append(tensor_name)
+
+    if json_list_tensors:
+        warnings.warn(
+            f" The following tensors are of type json or list: {json_list_tensors}. Collation of these tensors will fail by default. Transform these tensors by specifying a transform_fn or specify a custom collate_fn to handle these tensors.",
+        )
+
     return compressed_tensors
 
 

--- a/deeplake/integrations/pytorch/common.py
+++ b/deeplake/integrations/pytorch/common.py
@@ -76,7 +76,7 @@ def check_tensors(dataset, tensors):
 
     if json_list_tensors:
         warnings.warn(
-            f"The following tensors are of type json or list: {json_list_tensors}. Collation of these tensors will fail by default. Ensure that these tensors are either transformed by specifying a transform_fn or a custom collate_fn is specified to handle them."
+            f"The following tensors have json or list htype: {json_list_tensors}. Collation of these tensors will fail by default. Ensure that these tensors are either transformed by specifying a transform or a custom collate_fn is specified to handle them."
         )
 
     return compressed_tensors

--- a/deeplake/integrations/pytorch/common.py
+++ b/deeplake/integrations/pytorch/common.py
@@ -76,7 +76,7 @@ def check_tensors(dataset, tensors):
 
     if json_list_tensors:
         warnings.warn(
-            f" The following tensors are of type json or list: {json_list_tensors}. Collation of these tensors will fail by default. Transform these tensors by specifying a transform_fn or specify a custom collate_fn to handle these tensors.",
+            f"The following tensors are of type json or list: {json_list_tensors}. Collation of these tensors will fail by default. Ensure that these tensors are either transformed by specifying a transform_fn or a custom collate_fn is specified to handle them."
         )
 
     return compressed_tensors

--- a/deeplake/integrations/pytorch/dataset.py
+++ b/deeplake/integrations/pytorch/dataset.py
@@ -72,15 +72,6 @@ def copy_tensor(x):
         copy = x.copy()
     if isinstance(copy, Polygons):
         copy = copy.numpy()
-    try:
-        if copy.dtype == "object":
-            raise TypeError(
-                "Tensors of json htype cannot be converted to pytorch tensors automatically. \
-Provide a custom collate function to handle this type of data. \
-Alternatively, you can also exclude these tensors from training using the `tensors` argument of `ds.pytorch()`"
-            )
-    except AttributeError:
-        pass
     return copy
 
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->