### PR TITLE
Allow the use of compute functions on read-only datasets

### DIFF
--- a/deeplake/core/transform/test_transform.py
+++ b/deeplake/core/transform/test_transform.py
@@ -138,6 +138,11 @@ def small_transform(sample_in, samples_out):
     samples_out.image.append(sample_in)
 
 
+@deeplake.compute
+def fn_aggregate(samples_in, samples_out, key, values):
+    values.append(samples_in[key].numpy().mean())
+
+
 def check_target_array(ds, index, target):
     np.testing.assert_array_equal(
         ds.img[index].numpy(), target * np.ones((200, 200, 3))
@@ -1028,3 +1033,110 @@ def test_transform_info(local_ds_generator):
         assert ds.info["test"] == 123
     ds = local_ds_generator()
     assert ds.info["test"] == 123
+
+
+@parametrize_num_workers
+@all_schedulers
+@all_compressions
+@pytest.mark.parametrize(
+    "ds",
+    ["memory_ds", "local_ds", "s3_ds"],
+    indirect=True,
+)
+def test_read_only_dataset_aggregation_image(
+    ds, sample_compression, scheduler, num_workers
+):
+    if scheduler == "processed" and ds.path.startswith("mem://"):
+        pytest.xfail("Memory dataset not supported in processed scheduler")
+
+    i_start = 0
+    i_stop = 100
+    with ds:
+        ds.create_tensor("image", htype="image", sample_compression=sample_compression)
+        for i in range(i_start, i_stop):
+            ds.image.append(i * np.ones((9, 16), dtype="uint8"))
+    ds.read_only = True
+
+    values = []
+    fn_aggregate(key="image", values=values).eval(
+        ds,
+        num_workers=num_workers,
+        progressbar=False,
+        scheduler=scheduler,
+        read_only_ok=True,
+    )
+    assert len(values) == i_stop - i_start
+    assert np.array(values).mean() == (i_start + i_stop - 1) / 2  # half-open interval
+
+
+@parametrize_num_workers
+@all_schedulers
+@pytest.mark.parametrize(
+    "ds",
+    ["memory_ds", "local_ds", "s3_ds"],
+    indirect=True,
+)
+def test_read_only_dataset_aggregation_label(ds, scheduler, num_workers):
+    if scheduler == "processed" and ds.path.startswith("mem://"):
+        pytest.xfail("Memory dataset not supported in processed scheduler")
+
+    i_start = 0
+    i_stop = 100
+    with ds:
+        ds.create_tensor("label", htype="class_label")
+        for i in range(i_start, i_stop):
+            ds.label.append(i)
+    ds.read_only = True
+
+    values = []
+    fn_aggregate(key="label", values=values).eval(
+        ds,
+        num_workers=num_workers,
+        progressbar=False,
+        scheduler=scheduler,
+        read_only_ok=True,
+    )
+    assert len(values) == i_stop - i_start
+    assert np.array(values).mean() == (i_start + i_stop - 1) / 2  # half-open interval
+
+
+@parametrize_num_workers
+@all_schedulers
+@pytest.mark.parametrize(
+    "ds",
+    ["memory_ds", "local_ds", "s3_ds"],
+    indirect=True,
+)
+def test_read_only_dataset_raise(ds, scheduler, num_workers):
+    if scheduler == "processed" and ds.path.startswith("mem://"):
+        pytest.xfail("Memory dataset not supported in processed scheduler")
+
+    with ds:
+        ds.create_tensor("label", htype="class_label")
+        ds.label.append(1)
+    ds.read_only = True
+
+    with pytest.raises(InvalidOutputDatasetError):
+        values = []
+        fn_aggregate(key="label", values=values).eval(
+            ds, num_workers=num_workers, progressbar=False, scheduler=scheduler
+        )
+
+
+def test_read_only_dataset_raise_if_output_dataset(memory_ds):
+    data_in = memory_ds
+
+    with data_in:
+        data_in.create_tensor("label", htype="class_label")
+        data_in.label.append(1)
+
+    data_out = deeplake.dataset(
+        "mem://test_read_only_dataset_raise_if_output_dataset", overwrite=True
+    )
+    data_out.read_only = True
+
+    with pytest.raises(InvalidOutputDatasetError):
+        values = []
+        fn_aggregate(key="label", values=values).eval(
+            data_in, data_out, progressbar=False, read_only_ok=True
+        )

--- a/deeplake/core/transform/transform.py
+++ b/deeplake/core/transform/transform.py
@@ -55,6 +55,7 @@ class ComputeFunction:
         skip_ok: bool = False,
         check_lengths: bool = True,
         pad_data_in: bool = False,
+        read_only_ok: bool = False,
         **kwargs,
     ):
         """Evaluates the ComputeFunction on data_in to produce an output dataset ds_out.
@@ -73,6 +74,8 @@ class ComputeFunction:
                 This is especially useful for inplace transformations in which certain tensors are not modified. Defaults to False.
             check_lengths (bool): If True, checks whether ds_out has tensors of same lengths initially.
             pad_data_in (bool): NOTE: This is only applicable if data_in is a Deep Lake dataset. If True, pads tensors of data_in to match the length of the largest tensor in data_in.
+                Defaults to False.
+            read_only_ok (bool): If ``True`` and output dataset is same as input dataset, the read-only check is skipped. This can be used to read data in parallel without making changes to underlying dataset.
                 Defaults to False.
             **kwargs: Additional arguments.
 
@@ -93,6 +96,7 @@ class ComputeFunction:
             skip_ok,
             check_lengths,
             pad_data_in,
+            read_only_ok,
             **kwargs,
         )
 
@@ -118,6 +122,7 @@ class Pipeline:
         skip_ok: bool = False,
         check_lengths: bool = True,
         pad_data_in: bool = False,
+        read_only_ok: bool = False,
         **kwargs,
     ):
         """Evaluates the pipeline on ``data_in`` to produce an output dataset ``ds_out``.
@@ -137,6 +142,8 @@ class Pipeline:
             check_lengths (bool): If ``True``, checks whether ``ds_out`` has tensors of same lengths initially.
             pad_data_in (bool): If ``True``, pads tensors of ``data_in`` to match the length of the largest tensor in ``data_in``.
                 Defaults to ``False``.
+            read_only_ok (bool): If ``True`` and output dataset is same as input dataset, the read-only check is skipped.
+                Defaults to False.
             **kwargs: Additional arguments.
 
         Raises:
@@ -186,7 +193,9 @@ class Pipeline:
 
         target_ds = data_in if overwrite else ds_out
 
-        check_transform_ds_out(target_ds, scheduler, check_lengths)
+        check_transform_ds_out(
+            target_ds, scheduler, check_lengths, read_only_ok and overwrite
+        )
 
         # if overwrite then we've already flushed and autocheckecked out data_in which is target_ds now
         if not overwrite:
@@ -214,6 +223,7 @@ class Pipeline:
                 progressbar,
                 overwrite,
                 skip_ok,
+                read_only_ok and overwrite,
                 **kwargs,
             )
             target_ds._send_compute_progress(**progress_end_args, status="success")
@@ -241,6 +251,7 @@ class Pipeline:
         progressbar: bool = True,
         overwrite: bool = False,
         skip_ok: bool = False,
+        read_only: bool = False,
         **kwargs,
     ):
         """Runs the pipeline on the input data to produce output samples and stores in the dataset.
@@ -255,6 +266,7 @@ class Pipeline:
                 tensor.key
                 for tensor in target_ds.tensors.values()
                 if tensor.base_htype == "class_label"
+                and not read_only
                 and not tensor.meta._disable_temp_transform
             ]
             if not kwargs.get("disable_label_sync")
@@ -267,19 +279,20 @@ class Pipeline:
             else [target_ds[t].key for t in target_ds.tensors]
         )
 
-        for tensor in class_label_tensors:
-            temp_tensor = f"__temp{tensor}_{uuid4().hex[:4]}"
-            with target_ds:
-                temp_tensor_obj = target_ds.create_tensor(
-                    temp_tensor,
-                    htype="class_label",
-                    create_sample_info_tensor=False,
-                    create_shape_tensor=False,
-                    create_id_tensor=False,
-                )
-                temp_tensor_obj.meta._disable_temp_transform = True
-                label_temp_tensors[tensor] = temp_tensor
-            target_ds.flush()
+        if not read_only:
+            for tensor in class_label_tensors:
+                temp_tensor = f"__temp{tensor}_{uuid4().hex[:4]}"
+                with target_ds:
+                    temp_tensor_obj = target_ds.create_tensor(
+                        temp_tensor,
+                        htype="class_label",
+                        create_sample_info_tensor=False,
+                        create_shape_tensor=False,
+                        create_id_tensor=False,
+                    )
+                    temp_tensor_obj.meta._disable_temp_transform = True
+                    label_temp_tensors[tensor] = temp_tensor
+                target_ds.flush()
 
         visible_tensors = list(target_ds.tensors)
         visible_tensors = [target_ds[t].key for t in visible_tensors]
@@ -323,6 +336,9 @@ class Pipeline:
             for tensor in label_temp_tensors.values():
                 target_ds.delete_tensor(tensor)
             raise e
+
+        if read_only:
+            return
 
         result = process_transform_result(result)
 

--- a/deeplake/util/transform.py
+++ b/deeplake/util/transform.py
@@ -365,10 +365,13 @@ def check_transform_data_in(data_in, scheduler: str) -> None:
 
 
 def check_transform_ds_out(
-    ds_out: deeplake.Dataset, scheduler: str, check_lengths: bool
+    ds_out: deeplake.Dataset,
+    scheduler: str,
+    check_lengths: bool,
+    read_only_ok: bool = False,
 ) -> None:
     """Checks whether the ds_out for a transform is valid or not."""
-    if ds_out._read_only:
+    if ds_out._read_only and not read_only_ok:
         raise InvalidOutputDatasetError
     tensors = list(ds_out.tensors)
 


### PR DESCRIPTION
Since these can be used to iterate a dataset with paralization in an easy way.

## 🚀 🚀 Pull Request

See https://github.com/activeloopai/deeplake/issues/2002

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->