### PR TITLE
[CUS-56] Restrict characters in dataset names

### DIFF
--- a/deeplake/api/dataset.py
+++ b/deeplake/api/dataset.py
@@ -12,7 +12,7 @@ from deeplake.client.log import logger
 from deeplake.core.dataset import Dataset, dataset_factory
 from deeplake.core.meta.dataset_meta import DatasetMeta
 from deeplake.util.connect_dataset import connect_dataset_entry
-from deeplake.util.path import convert_pathlib_to_string_if_needed
+from deeplake.util.path import convert_pathlib_to_string_if_needed, verify_dataset_name
 from deeplake.hooks import (
     dataset_created,
     dataset_loaded,
@@ -138,6 +138,8 @@ class dataset:
         access_method, num_workers, scheduler = parse_access_method(access_method)
         check_access_method(access_method, overwrite)
         path = convert_pathlib_to_string_if_needed(path)
+
+        verify_dataset_name(path)
 
         if creds is None:
             creds = {}
@@ -282,6 +284,8 @@ class dataset:
             Setting ``overwrite`` to ``True`` will delete all of your data if it exists! Be very careful when setting this parameter.
         """
         path = convert_pathlib_to_string_if_needed(path)
+
+        verify_dataset_name(path)
 
         if creds is None:
             creds = {}
@@ -786,6 +790,8 @@ class dataset:
 
         src = convert_pathlib_to_string_if_needed(src)
         dest = convert_pathlib_to_string_if_needed(dest)
+
+        verify_dataset_name(dest)
 
         report_params = {
             "Overwrite": overwrite,

--- a/deeplake/api/tests/test_api.py
+++ b/deeplake/api/tests/test_api.py
@@ -38,8 +38,9 @@ from deeplake.util.exceptions import (
     UserNotLoggedInException,
     SampleAppendingError,
     DatasetTooLargeToDelete,
+    InvalidDatasetNameException,
 )
-from deeplake.util.path import convert_string_to_pathlib_if_needed
+from deeplake.util.path import convert_string_to_pathlib_if_needed, verify_dataset_name
 from deeplake.util.pretty_print import summary_tensor, summary_dataset
 from deeplake.constants import GDRIVE_OPT, MB
 from deeplake.client.config import REPORTING_CONFIG_FILE_PATH
@@ -2231,3 +2232,26 @@ def test_iter_warning(local_ds):
 
         with pytest.warns(UserWarning):
             ds.abc[10]
+
+
+def test_invalid_ds_name():
+    with pytest.raises(InvalidDatasetNameException):
+        deeplake.dataset("folder/datasets/dataset name *")
+
+    verify_dataset_name("folders/datasets/dataset name")
+
+    with pytest.raises(InvalidDatasetNameException):
+        ds = deeplake.dataset("hub://test/Mnist 123")
+
+    with pytest.raises(InvalidDatasetNameException):
+        ds = deeplake.empty("hub://test/ Mnist123")
+
+    with pytest.raises(InvalidDatasetNameException):
+        ds = deeplake.like("hub://test/Mnist123 ", "hub://activeloop/mnist-train")
+
+    with pytest.raises(InvalidDatasetNameException):
+        ds = deeplake.deepcopy(
+            "hub://activeloop/mnist-train", "hub://activeloop/mnist$train"
+        )
+
+    verify_dataset_name("hub://test/data-set_123")

--- a/deeplake/tests/common.py
+++ b/deeplake/tests/common.py
@@ -60,7 +60,7 @@ parametrize_num_workers = pytest.mark.parametrize(NUM_WORKERS_PARAM, NUM_WORKERS
 def current_test_name() -> str:
     full_name = os.environ.get("PYTEST_CURRENT_TEST").split(" ")[0]  # type: ignore
     test_file = full_name.split("::")[0].split("/")[-1].split(".py")[0]
-    test_name = full_name.split("::")[1]
+    test_name = full_name.split("::")[1].replace("[", "-").replace("]", "")
     output = posixpath.join(test_file, test_name)
     return output
 

--- a/deeplake/tests/common.py
+++ b/deeplake/tests/common.py
@@ -9,6 +9,7 @@ import numpy as np
 import posixpath
 import pytest
 import sys
+import re
 
 from deeplake.constants import KB, MB
 
@@ -60,7 +61,8 @@ parametrize_num_workers = pytest.mark.parametrize(NUM_WORKERS_PARAM, NUM_WORKERS
 def current_test_name() -> str:
     full_name = os.environ.get("PYTEST_CURRENT_TEST").split(" ")[0]  # type: ignore
     test_file = full_name.split("::")[0].split("/")[-1].split(".py")[0]
-    test_name = full_name.split("::")[1].replace("[", "-").replace("]", "")
+    test_name = full_name.split("::")[1]
+    test_name = re.sub(r"[^A-Za-z0-9_-]", "-", test_name)
     output = posixpath.join(test_file, test_name)
     return output
 

--- a/deeplake/util/exceptions.py
+++ b/deeplake/util/exceptions.py
@@ -829,7 +829,7 @@ class GroupInfoNotSupportedError(Exception):
 class InvalidDatasetNameException(Exception):
     def __init__(self, path_type):
         if path_type == "local":
-            message = "Local dataset names can only contain letters, numbers, hyphens, underscores and spaces."
+            message = "Local dataset names can only contain letters, numbers, spaces, `-`, `_` and `.`."
         else:
             message = "Please specify a dataset name that contains only letters, numbers, hyphens and underscores."
         super().__init__(message)

--- a/deeplake/util/exceptions.py
+++ b/deeplake/util/exceptions.py
@@ -825,6 +825,7 @@ class GroupInfoNotSupportedError(Exception):
         message = "Tensor groups does not have info attribute. Please use `dataset.info` or `dataset.tensor.info`."
         super().__init__(message)
 
+
 class InvalidDatasetNameException(Exception):
     def __init__(self, path_type):
         if path_type == "local":

--- a/deeplake/util/exceptions.py
+++ b/deeplake/util/exceptions.py
@@ -824,3 +824,11 @@ class GroupInfoNotSupportedError(Exception):
     def __init__(self):
         message = "Tensor groups does not have info attribute. Please use `dataset.info` or `dataset.tensor.info`."
         super().__init__(message)
+
+class InvalidDatasetNameException(Exception):
+    def __init__(self, path_type):
+        if path_type == "local":
+            message = "Local dataset names can only contain letters, numbers, hyphens, underscores and spaces."
+        else:
+            message = "Please specify a dataset name that contains only letters, numbers, hyphens and underscores."
+        super().__init__(message)

--- a/deeplake/util/path.py
+++ b/deeplake/util/path.py
@@ -10,7 +10,7 @@ import os
 import re
 
 CLOUD_DS_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]*$")
-LOCAL_DS_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_ -]*$")
+LOCAL_DS_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_ .-]*$")
 
 
 def is_hub_cloud_path(path: str):
@@ -117,12 +117,11 @@ def get_org_id_and_ds_name(path):
 
 def verify_dataset_name(path):
     path_type = get_path_type(path)
-    ds_name = posixpath.split(path)[-1]
+    ds_name = os.path.split(path)[-1]
+    match = True
     if path_type == "local":
         match = bool(LOCAL_DS_NAME_PATTERN.match(ds_name))
-        if not match:
-            raise InvalidDatasetNameException(path_type)
-    else:
+    elif "/queries/" not in path:
         match = bool(CLOUD_DS_NAME_PATTERN.match(ds_name))
-        if not match:
-            raise InvalidDatasetNameException(path_type)
+    if not match:
+        raise InvalidDatasetNameException(path_type)


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
- Only letters, numbers, hyphens and underscores are allowed in cloud dataset names
- Local dataset names can have spaces in addition
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->