### PR TITLE
[CUS-57] [CUS-58] In place ds connect

### DIFF
--- a/deeplake/api/dataset.py
+++ b/deeplake/api/dataset.py
@@ -941,9 +941,9 @@ class dataset:
 
         Examples:
             >>> # Connect an s3 dataset
-            >>> ds = deeplake.connect(src_path="s3://bucket/dataset", dest_path="hub://my_org/dataset", creds_key="my_managed_credentials_key")
+            >>> ds = deeplake.connect(src_path="s3://bucket/dataset", dest_path="hub://my_org/dataset", creds_key="my_managed_credentials_key", token="my_activeloop_token")
             >>> # or
-            >>> ds = deeplake.connect(src_path="s3://bucket/dataset", org_id="my_org", creds_key="my_managed_credentials_key")
+            >>> ds = deeplake.connect(src_path="s3://bucket/dataset", org_id="my_org", creds_key="my_managed_credentials_key", token="my_activeloop_token")
 
         Args:
             src_path (str): Cloud path to the source dataset. Can be:

--- a/deeplake/api/dataset.py
+++ b/deeplake/api/dataset.py
@@ -963,7 +963,7 @@ class dataset:
             InvalidSourcePathError: If the ``src_path`` is not a valid s3 or gcs path.
             InvalidDestinationPathError: If ``dest_path``, or ``org_id`` and ``ds_name`` do not form a valid Deep Lake path.
         """
-        return connect_dataset_entry(
+        path = connect_dataset_entry(
             src_path=src_path,
             creds_key=creds_key,
             dest_path=dest_path,
@@ -971,6 +971,7 @@ class dataset:
             ds_name=ds_name,
             token=token,
         )
+        return deeplake.dataset(path, token=token, verbose=False)
 
     @staticmethod
     def ingest(

--- a/deeplake/api/tests/test_connect_datasets.py
+++ b/deeplake/api/tests/test_connect_datasets.py
@@ -27,7 +27,7 @@ def test_connect_dataset_api(
     assert ds.x[0].numpy() == 10
 
 
-def test_connect_dataset_object(
+def test_in_place_dataset_connect(
     hub_cloud_dev_token,
     hub_cloud_path,
     hub_cloud_dev_managed_creds_key,
@@ -37,16 +37,16 @@ def test_connect_dataset_object(
     s3_ds.create_tensor("x")
     s3_ds.x.append(10)
 
-    ds = s3_ds.connect(
+    s3_ds.connect(
         creds_key=hub_cloud_dev_managed_creds_key,
         dest_path=hub_cloud_path,
         token=hub_cloud_dev_token,
     )
+    s3_ds.add_creds_key(hub_cloud_dev_managed_creds_key, managed=True)
 
-    assert ds is not None
-    assert ds.path.startswith("hub://")
-    assert "x" in ds.tensors
-    assert ds.x[0].numpy() == 10
+    assert s3_ds.path.startswith("hub://")
+    assert "x" in s3_ds.tensors
+    assert s3_ds.x[0].numpy() == 10
 
 
 def test_connect_dataset_cases(local_ds, memory_ds, hub_cloud_ds):

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -3443,14 +3443,22 @@ class Dataset:
             InvalidSourcePathError: If the dataset's path is not a valid s3 or gcs path.
             InvalidDestinationPathError: If ``dest_path``, or ``org_id`` and ``ds_name`` do not form a valid Deep Lake path.
         """
-        return connect_dataset_entry(
+        self.__class__ = (
+            deeplake.core.dataset.deeplake_cloud_dataset.DeepLakeCloudDataset
+        )
+        path = connect_dataset_entry(
             src_path=self.path,
-            creds_key=creds_key,
             dest_path=dest_path,
             org_id=org_id,
             ds_name=ds_name,
+            creds_key=creds_key,
             token=token,
         )
+        self._token = token
+        self.path = path
+        self.public = False
+        self._load_link_creds()
+        self._first_load_init(verbose=False)
 
     def add_creds_key(self, creds_key: str, managed: bool = False):
         """Adds a new creds key to the dataset. These keys are used for tensors that are linked to external data.

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -3424,9 +3424,9 @@ class Dataset:
         Examples:
             >>> # create/load an s3 dataset
             >>> s3_ds = deeplake.dataset("s3://bucket/dataset")
-            >>> ds = s3_ds.connect(dest_path="hub://my_org/dataset", creds_key="my_managed_credentials_key")
+            >>> ds = s3_ds.connect(dest_path="hub://my_org/dataset", creds_key="my_managed_credentials_key", token="my_activeloop_token)
             >>> # or
-            >>> ds = s3_ds.connect(org_id="my_org", creds_key="my_managed_credentials_key")
+            >>> ds = s3_ds.connect(org_id="my_org", creds_key="my_managed_credentials_key", token="my_activeloop_token")
 
         Args:
             creds_key (str): The managed credentials to be used for accessing the source path.
@@ -3435,9 +3435,6 @@ class Dataset:
             org_id (str, optional): The organization to where the connected Deep Lake dataset will be added.
             ds_name (str, optional): The name of the connected Deep Lake dataset. Will be infered from ``dest_path`` or ``src_path`` if not provided.
             token (str, optional): Activeloop token used to fetch the managed credentials.
-
-        Returns:
-            Dataset: The connected Deep Lake dataset.
 
         Raises:
             InvalidSourcePathError: If the dataset's path is not a valid s3 or gcs path.

--- a/deeplake/util/connect_dataset.py
+++ b/deeplake/util/connect_dataset.py
@@ -27,7 +27,7 @@ def connect_dataset_entry(
     ds_name: Optional[str] = None,
     token: Optional[str] = None,
     verbose: bool = True,
-):
+) -> str:
     dataset_entry = DatasetEntry(src_path, creds_key, dest_path, org_id, ds_name, token)
     dataset_entry.validate()
     connected_id = dataset_entry.connect_dataset_entry()
@@ -43,7 +43,7 @@ def connect_dataset_entry(
     if verbose:
         log_dataset_connection_success(result_path)
 
-    return deeplake.dataset(result_path, token=token, verbose=False)
+    return result_path
 
 
 class DatasetEntry:


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
Added `token` parameter examples in docstrings.

The idea is for `ds.connect` to modify the underlying dataset object and convert it to a `DeepLakeCloudDataset` so that all the features, like managed creds keys, are accessible immediately without the need to reload the dataset.
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->