### PR TITLE
[DL-805] Groups + Loader fixes

### DIFF
--- a/deeplake/enterprise/dataloader.py
+++ b/deeplake/enterprise/dataloader.py
@@ -6,6 +6,7 @@ from deeplake.enterprise.util import (
     raise_indra_installation_error,
     verify_base_storage,
 )
+from deeplake.hooks import dataset_read
 from deeplake.enterprise.libdeeplake_query import query, sample_by
 from deeplake.integrations.pytorch.common import (
     PytorchTransformFunction,
@@ -441,6 +442,7 @@ class DeepLakeDataLoader(DataLoader):
                 compressed_tensors=compressed_tensors,
                 persistent_workers=self._persistent_workers,
             )
+        dataset_read(self._orig_dataset)
         return iter(self._dataloader)
 
 

--- a/deeplake/enterprise/test_pytorch.py
+++ b/deeplake/enterprise/test_pytorch.py
@@ -331,6 +331,13 @@ def test_groups(hub_cloud_ds, compressed_image_paths):
         assert cat[0].shape == another_ds.images.jpegs.cats[i].numpy().shape
         assert flower[0].shape == another_ds.images.pngs.flowers[i].numpy().shape
 
+    dl = another_ds.images.dataloader().pytorch(return_index=False)
+    for sample in dl:
+        cat = sample["jpegs/cats"]
+        flower = sample["pngs/flowers"]
+        np.testing.assert_array_equal(cat[0], img1.array)
+        np.testing.assert_array_equal(flower[0], img2.array)
+
 
 @requires_torch
 @requires_libdeeplake

--- a/deeplake/integrations/pytorch/dataset.py
+++ b/deeplake/integrations/pytorch/dataset.py
@@ -508,7 +508,6 @@ class SubIterableDataset(torch.utils.data.IterableDataset):
         self.num_workers = num_workers
         self.batch_size = batch_size
         self.buffer_size = buffer_size * MB
-
         if self.buffer_size == 0:
             warn("setting buffer_size = 0 will result in poor shuffling distribution")
 

--- a/deeplake/integrations/pytorch/pytorch.py
+++ b/deeplake/integrations/pytorch/pytorch.py
@@ -3,7 +3,6 @@ from deeplake.util.dataset import try_flushing
 from deeplake.util.dataset import map_tensor_keys
 from .common import (
     PytorchTransformFunction,
-    check_tensors,
     convert_fn as default_convert_fn,
     collate_fn as default_collate_fn,
 )

--- a/deeplake/integrations/tests/test_pytorch.py
+++ b/deeplake/integrations/tests/test_pytorch.py
@@ -445,7 +445,9 @@ def test_groups(local_ds, compressed_image_paths):
             local_ds.arrays.y.append(np.random.random((4, 5)))
 
     dl = local_ds.images.pytorch(return_index=False)
-    for cat, flower in dl:
+    for sample in dl:
+        cat = sample["jpegs/cats"]
+        flower = sample["pngs/flowers"]
         np.testing.assert_array_equal(cat[0], img1.array)
         np.testing.assert_array_equal(flower[0], img2.array)
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
ds.group.pytorch or ds['group'].pytorch() should return tensor names without the group name in front
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->