### PR TITLE
Reduce IPC overhead for enterprise loader + jpeg tensors with numpy decode method

### DIFF
--- a/deeplake/enterprise/dataloader.py
+++ b/deeplake/enterprise/dataloader.py
@@ -418,7 +418,7 @@ class DeepLakeDataLoader(DataLoader):
             dataset = dataset_to_libdeeplake(self._orig_dataset)
 
             jpeg_png_compressed_tensors = check_tensors(self._orig_dataset, tensors)
-            raw_tensors, pil_tensors = validate_decode_method(
+            raw_tensors, jpeg_png_numpy_tensors, jpeg_png_pil_tensors = validate_decode_method(
                 self._decode_method, tensors, jpeg_png_compressed_tensors
             )
             raw_tensors.extend(jpeg_png_compressed_tensors)
@@ -439,7 +439,8 @@ class DeepLakeDataLoader(DataLoader):
                 primary_tensor=primary_tensor_name,
                 buffer_size=buffer_size,
                 raw_tensors=raw_tensors,
-                pil_tensors=pil_tensors,
+                jpeg_png_numpy_tensors=jpeg_png_numpy_tensors,
+                jpeg_png_pil_tensors=jpeg_png_pil_tensors,
                 jpeg_png_compressed_tensors=jpeg_png_compressed_tensors,
                 persistent_workers=self._persistent_workers,
             )

--- a/deeplake/enterprise/dataloader.py
+++ b/deeplake/enterprise/dataloader.py
@@ -418,10 +418,10 @@ class DeepLakeDataLoader(DataLoader):
             dataset = dataset_to_libdeeplake(self._orig_dataset)
 
             jpeg_png_compressed_tensors = check_tensors(self._orig_dataset, tensors)
-            raw_tensors, compressed_tensors = validate_decode_method(
+            raw_tensors, pil_tensors = validate_decode_method(
                 self._decode_method, tensors, jpeg_png_compressed_tensors
             )
-            raw_tensors.extend(compressed_tensors)
+            raw_tensors.extend(jpeg_png_compressed_tensors)
             self._dataloader = INDRA_LOADER(
                 dataset,
                 batch_size=self._batch_size,
@@ -439,7 +439,8 @@ class DeepLakeDataLoader(DataLoader):
                 primary_tensor=primary_tensor_name,
                 buffer_size=buffer_size,
                 raw_tensors=raw_tensors,
-                compressed_tensors=compressed_tensors,
+                pil_tensors=pil_tensors,
+                jpeg_png_compressed_tensors=jpeg_png_compressed_tensors,
                 persistent_workers=self._persistent_workers,
             )
         dataset_read(self._orig_dataset)

--- a/deeplake/integrations/pytorch/common.py
+++ b/deeplake/integrations/pytorch/common.py
@@ -85,13 +85,14 @@ def check_tensors(dataset, tensors):
 
 def validate_decode_method(decode_method, all_tensor_keys, jpeg_png_compressed_tensors):
     raw_tensors = []
-    pil_tensors = []
+    jpeg_png_numpy_tensors = []
+    jpeg_png_pil_tensors = []
     if decode_method is None:
         if len(jpeg_png_compressed_tensors) > 0:
             warnings.warn(
                 f"Decode method for tensors {jpeg_png_compressed_tensors} is defaulting to numpy. Please consider specifying a decode_method in .pytorch() that maximizes the data preprocessing speed based on your transformation."
             )
-        return raw_tensors, pil_tensors
+        return [], jpeg_png_compressed_tensors, []
 
     jpeg_png_compressed_tensors_set = set(jpeg_png_compressed_tensors)
     generic_supported_decode_methods = {"numpy", "tobytes"}
@@ -113,9 +114,11 @@ def validate_decode_method(decode_method, all_tensor_keys, jpeg_png_compressed_t
         if decode_method == "tobytes":
             raw_tensors.append(tensor_name)
         elif decode_method == "pil":
-            pil_tensors.append(tensor_name)
+            jpeg_png_pil_tensors.append(tensor_name)
 
-    return raw_tensors, pil_tensors
+    jpeg_png_numpy_tensors = list(set(jpeg_png_compressed_tensors) - set(raw_tensors) - set(jpeg_png_pil_tensors))
+
+    return raw_tensors, jpeg_png_numpy_tensors, jpeg_png_pil_tensors
 
 
 def get_collate_fn(collate, mode):

--- a/deeplake/integrations/pytorch/common.py
+++ b/deeplake/integrations/pytorch/common.py
@@ -85,13 +85,13 @@ def check_tensors(dataset, tensors):
 
 def validate_decode_method(decode_method, all_tensor_keys, jpeg_png_compressed_tensors):
     raw_tensors = []
-    compressed_tensors = []
+    pil_tensors = []
     if decode_method is None:
         if len(jpeg_png_compressed_tensors) > 0:
             warnings.warn(
                 f"Decode method for tensors {jpeg_png_compressed_tensors} is defaulting to numpy. Please consider specifying a decode_method in .pytorch() that maximizes the data preprocessing speed based on your transformation."
             )
-        return raw_tensors, compressed_tensors
+        return raw_tensors, pil_tensors
 
     jpeg_png_compressed_tensors_set = set(jpeg_png_compressed_tensors)
     generic_supported_decode_methods = {"numpy", "tobytes"}
@@ -113,9 +113,9 @@ def validate_decode_method(decode_method, all_tensor_keys, jpeg_png_compressed_t
         if decode_method == "tobytes":
             raw_tensors.append(tensor_name)
         elif decode_method == "pil":
-            compressed_tensors.append(tensor_name)
+            pil_tensors.append(tensor_name)
 
-    return raw_tensors, compressed_tensors
+    return raw_tensors, pil_tensors
 
 
 def get_collate_fn(collate, mode):


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->