### PR TITLE
[CUS-59] Overwrite parameter for create_tensor

### DIFF
--- a/deeplake/api/tests/test_api.py
+++ b/deeplake/api/tests/test_api.py
@@ -2255,3 +2255,17 @@ def test_invalid_ds_name():
         )
 
     verify_dataset_name("hub://test/data-set_123")
+
+
+def test_create_tensor_overwrite(local_ds):
+    with local_ds as ds:
+        ds.create_tensor("abc")
+        ds.abc.extend([1, 2, 3, 4, 5])
+
+    with pytest.raises(TensorAlreadyExistsError):
+        ds.create_tensor("abc")
+
+    ds.create_tensor("abc", overwrite=True)
+    ds.abc.extend([1, 2, 3])
+
+    assert ds.abc.numpy().flatten().tolist() == [1, 2, 3]


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
- Added `overwrite` param for `create_tensor`.
- Removed `exist_ok` param for `create_tensor`.
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->