### PR TITLE
[AL-2077] Automatically rechunk at end of transform

### DIFF
--- a/deeplake/api/tests/test_api.py
+++ b/deeplake/api/tests/test_api.py
@@ -1670,6 +1670,17 @@ def test_sequence_shapes(memory_ds):
         assert ds.abc.shape_interval.upper == (2, 4, 1)
 
 
+def test_sequence_len(memory_ds):
+    with memory_ds as ds:
+        ds.create_tensor("abc", htype="sequence")
+        ds.abc.extend([[1, 2, 3], [4, 5], [6, 7, 8]])
+
+        assert len(ds.abc) == 3
+        assert len(ds.abc[0]) == 3
+        assert len(ds.abc[1]) == 2
+        assert len(ds.abc[2]) == 3
+
+
 def test_shape_bug(memory_ds):
     ds = memory_ds
     ds.create_tensor("x")

--- a/deeplake/api/tests/test_rechunk.py
+++ b/deeplake/api/tests/test_rechunk.py
@@ -129,7 +129,10 @@ def test_rechunk_text(local_ds_generator):
     with local_ds_generator() as ds:
         ds.create_tensor("abc", "text")
         add_sample_in().eval(
-            ["hello", "world", "abc", "def", "ghi", "yo"], ds, num_workers=2
+            ["hello", "world", "abc", "def", "ghi", "yo"],
+            ds,
+            num_workers=2,
+            disable_rechunk=True,
         )
 
         assert len(ds.abc.chunk_engine.chunk_id_encoder.array) == 2
@@ -175,7 +178,10 @@ def test_rechunk_list(local_ds_generator):
     with local_ds_generator() as ds:
         ds.create_tensor("abc", "list")
         add_sample_in().eval(
-            [["hello", "world"], ["abc", "def", "ghi"], ["yo"]], ds, num_workers=2
+            [["hello", "world"], ["abc", "def", "ghi"], ["yo"]],
+            ds,
+            num_workers=2,
+            disable_rechunk=True,
         )
 
         assert len(ds.abc.chunk_engine.chunk_id_encoder.array) == 2

--- a/deeplake/api/tests/test_rechunk.py
+++ b/deeplake/api/tests/test_rechunk.py
@@ -155,7 +155,10 @@ def test_rechunk_json(local_ds_generator):
     with local_ds_generator() as ds:
         ds.create_tensor("abc", "json")
         add_sample_in().eval(
-            [{"one": "if"}, {"two": "elif"}, {"three": "else"}], ds, num_workers=2
+            [{"one": "if"}, {"two": "elif"}, {"three": "else"}],
+            ds,
+            num_workers=2,
+            disable_rechunk=True,
         )
 
         assert len(ds.abc.chunk_engine.chunk_id_encoder.array) == 2

--- a/deeplake/core/chunk/base_chunk.py
+++ b/deeplake/core/chunk/base_chunk.py
@@ -570,6 +570,11 @@ class BaseChunk(DeepLakeMemoryObject):
         return len(self.tensor_meta.max_shape) == 0 and len(self.data_bytes) == 0
 
     def _text_sample_to_byte_string(self, sample):
+        if isinstance(sample, deeplake.Tensor):
+            try:
+                return sample.numpy(aslist=True)[0].encode("utf-8")
+            except AttributeError:
+                return b""
         try:
             return sample.encode("utf-8")
         except AttributeError:

--- a/deeplake/core/chunk/base_chunk.py
+++ b/deeplake/core/chunk/base_chunk.py
@@ -572,7 +572,7 @@ class BaseChunk(DeepLakeMemoryObject):
     def _text_sample_to_byte_string(self, sample):
         if isinstance(sample, deeplake.Tensor):
             try:
-                return sample.numpy(aslist=True)[0]
+                return sample.numpy(aslist=True)[0].encode("utf-8")
             except AttributeError:
                 return b""
         try:

--- a/deeplake/core/chunk/base_chunk.py
+++ b/deeplake/core/chunk/base_chunk.py
@@ -572,7 +572,7 @@ class BaseChunk(DeepLakeMemoryObject):
     def _text_sample_to_byte_string(self, sample):
         if isinstance(sample, deeplake.Tensor):
             try:
-                return sample.numpy(aslist=True)[0].encode("utf-8")
+                return sample.numpy(aslist=True)[0]
             except AttributeError:
                 return b""
         try:

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -745,6 +745,7 @@ class Dataset:
         shape_tensor = get_sample_shape_tensor_key(tensor)
         self.create_tensor(
             shape_tensor,
+            dtype="int64",
             hidden=True,
             create_id_tensor=False,
             create_sample_info_tensor=False,
@@ -769,6 +770,7 @@ class Dataset:
         id_tensor = get_sample_id_tensor_key(tensor)
         self.create_tensor(
             id_tensor,
+            dtype="uint64",
             hidden=True,
             create_id_tensor=False,
             create_sample_info_tensor=False,
@@ -2378,9 +2380,11 @@ class Dataset:
             scheduler=scheduler,
             progressbar=progressbar,
             skip_ok=True,
+            check_lengths=False,
             extend_only=True,
             disable_label_sync=True,
-            disable_rechunk_check=True,     # avoid recursion
+            disable_rechunk=True,  # avoid recursion
+            update_commit_diff=False,
         )
 
     # the below methods are used by cloudpickle dumps

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -2380,6 +2380,7 @@ class Dataset:
             skip_ok=True,
             extend_only=True,
             disable_label_sync=True,
+            disable_rechunk_check=True,     # avoid recursion
         )
 
     # the below methods are used by cloudpickle dumps

--- a/deeplake/core/serialize.py
+++ b/deeplake/core/serialize.py
@@ -551,7 +551,11 @@ def serialize_tensor(
             store_tiles,
         )
 
-    if incoming_sample.meta.chunk_compression or chunk_compression:
+    if (
+        incoming_sample.meta.chunk_compression
+        or chunk_compression
+        or incoming_sample.meta.is_sequence  # fix for now. there is a bug with .tobytes for sequence sample.
+    ):
         return _return_numpy()
     elif incoming_sample.meta.sample_compression == sample_compression:
         # Pass through

--- a/deeplake/core/storage/google_drive.py
+++ b/deeplake/core/storage/google_drive.py
@@ -367,3 +367,10 @@ class GDriveProvider(StorageProvider):
                     pass
         if not prefix:
             self._delete_file(self.root_id)
+
+    def copy(self):
+        cls = self.__class__
+        new_provider = cls.__new__(cls)
+        new_provider.__setstate__(self.__getstate__())
+        new_provider.gid.path_id_map = self.gid.path_id_map
+        return new_provider

--- a/deeplake/core/tensor.py
+++ b/deeplake/core/tensor.py
@@ -581,8 +581,12 @@ class Tensor:
 
         # catch corrupted datasets / user tampering ASAP
         self.chunk_engine.validate_num_samples_is_synchronized()
-        
-        return self.shape[0]
+
+        num_samples = self.num_samples
+        if self.is_sequence and num_samples > 0:
+            return self.shape[0]
+
+        return self.index.length(num_samples)
 
     def __getitem__(
         self,

--- a/deeplake/core/tensor.py
+++ b/deeplake/core/tensor.py
@@ -581,8 +581,8 @@ class Tensor:
 
         # catch corrupted datasets / user tampering ASAP
         self.chunk_engine.validate_num_samples_is_synchronized()
-
-        return self.index.length(self.num_samples)
+        
+        return self.shape[0]
 
     def __getitem__(
         self,

--- a/deeplake/core/transform/test_transform.py
+++ b/deeplake/core/transform/test_transform.py
@@ -1152,6 +1152,21 @@ def test_rechunk_post_transform(local_ds):
     assert image_num_chunks == 4
 
 
+def test_none_rechunk_post_transform(local_ds):
+    @deeplake.compute
+    def upload(stuff, ds):
+        ds.abc.append(None)
+
+    with local_ds as ds:
+        ds.create_tensor("abc")
+
+    upload().eval(list(range(100)), ds, num_workers=2)
+
+    num_chunks = ds.abc.chunk_engine.num_chunks
+
+    assert num_chunks == 2
+
+
 @pytest.mark.parametrize(
     "compression", [{"sample_compression": "lz4"}, {"chunk_compression": "lz4"}, {}]
 )

--- a/deeplake/core/transform/test_transform.py
+++ b/deeplake/core/transform/test_transform.py
@@ -34,8 +34,8 @@ commit_or_not = pytest.mark.parametrize("do_commit", [True, False])
 @deeplake.compute
 def fn1(sample_in, samples_out, mul=1, copy=1):
     for _ in range(copy):
-        samples_out.image.append(np.ones((337, 200)) * sample_in * mul)
-        samples_out.label.append(np.ones((1,)) * sample_in * mul)
+        samples_out.image.append(np.ones((337, 200), dtype=np.uint8) * sample_in * mul)
+        samples_out.label.append(np.ones((1,), dtype=np.uint32) * sample_in * mul)
 
 
 @deeplake.compute
@@ -1130,3 +1130,19 @@ def test_read_only_dataset_raise_if_output_dataset(memory_ds):
         fn_aggregate(key="label", values=values).eval(
             data_in, data_out, progressbar=False, read_only_ok=True
         )
+
+
+def test_rechunk_post_transform(local_ds):
+    with local_ds as ds:
+        ds.create_tensor("image", htype="image", sample_compression="jpg")
+        ds.create_tensor("label", htype="class_label")
+
+    fn1().eval(list(range(100)), ds, num_workers=4)
+
+    label_num_chunks = ds.label.chunk_engine.num_chunks
+
+    assert label_num_chunks == 1
+
+    image_num_chunks = ds.image.chunk_engine.num_chunks
+
+    assert image_num_chunks == 4

--- a/deeplake/core/transform/test_transform.py
+++ b/deeplake/core/transform/test_transform.py
@@ -330,7 +330,8 @@ def test_chain_transform_list_small(local_ds, scheduler):
     for i in range(100):
         for index in range(6 * i, 6 * i + 6):
             np.testing.assert_array_equal(
-                ds_out[index].image.numpy(), 15 * i * np.ones((337, 200))
+                ds_out[index].image.numpy(),
+                np.asarray(15 * i * np.ones((337, 200)), dtype=np.uint8),
             )
             np.testing.assert_array_equal(
                 ds_out[index].label.numpy(), 15 * i * np.ones((1,))
@@ -391,7 +392,8 @@ def test_add_to_non_empty_dataset(local_ds, scheduler, do_commit):
     for i in range(100):
         for index in range(10 + 6 * i, 10 + 6 * i + 6):
             np.testing.assert_array_equal(
-                ds_out[index].image.numpy(), 15 * i * np.ones((337, 200))
+                ds_out[index].image.numpy(),
+                np.asarray(15 * i * np.ones((337, 200)), dtype=np.uint8),
             )
             np.testing.assert_array_equal(
                 ds_out[index].label.numpy(), 15 * i * np.ones((1,))
@@ -861,7 +863,8 @@ def test_transform_skip_ok(local_ds_generator):
     for i in range(100):
         for index in range(6 * i, 6 * i + 6):
             np.testing.assert_array_equal(
-                ds.image[index].numpy(), 15 * i * np.ones((337, 200))
+                ds.image[index].numpy(),
+                np.asarray(15 * i * np.ones((337, 200)), dtype=np.uint8),
             )
             np.testing.assert_array_equal(
                 ds.label[index].numpy(), 15 * i * np.ones((1,))
@@ -874,7 +877,8 @@ def test_transform_skip_ok(local_ds_generator):
     for i in range(100):
         for index in range(6 * i, 6 * i + 6):
             np.testing.assert_array_equal(
-                ds.image[index].numpy(), 15 * i * np.ones((337, 200))
+                ds.image[index].numpy(),
+                np.asarray(15 * i * np.ones((337, 200)), dtype=np.uint8),
             )
             np.testing.assert_array_equal(
                 ds.label[index].numpy(), 15 * i * np.ones((1,))

--- a/deeplake/core/transform/transform.py
+++ b/deeplake/core/transform/transform.py
@@ -247,9 +247,10 @@ class Pipeline:
                 rechunk_tensors = check_rechunk(target_ds.root)
                 if rechunk_tensors:
                     if progressbar:
-                        logger.info(f"Rechunking tensors: {rechunk_tensors}")
+                        logger.info(f"Optimizing tensors: {rechunk_tensors}")
                     target_ds.root.rechunk(
-                        tensors=rechunk_tensors, progressbar=progressbar
+                        tensors=rechunk_tensors,
+                        progressbar=progressbar,
                     )
 
     def run(

--- a/deeplake/core/transform/transform.py
+++ b/deeplake/core/transform/transform.py
@@ -34,6 +34,8 @@ from deeplake.util.exceptions import (
 from deeplake.hooks import dataset_written, dataset_read
 from deeplake.util.version_control import auto_checkout, load_meta
 from deeplake.util.class_label import sync_labels
+from deeplake.util.check_rechunk import check_rechunk
+from deeplake.client.log import logger
 import numpy as np
 
 
@@ -370,6 +372,12 @@ class Pipeline:
                 scheduler=scheduler,
                 verbose=progressbar,
             )
+
+        if not kwargs.get("disable_rechunk_check"):
+            rechunk_tensors = check_rechunk(target_ds)
+            logger.info(f"Rechunking tensors: {rechunk_tensors}")
+            if rechunk_tensors:
+                target_ds.rechunk(tensors=rechunk_tensors)
 
 
 def compose(functions: List[ComputeFunction]):  # noqa: DAR101, DAR102, DAR201, DAR401

--- a/deeplake/util/check_rechunk.py
+++ b/deeplake/util/check_rechunk.py
@@ -1,0 +1,21 @@
+from deeplake.core.dataset import Dataset
+import numpy as np
+
+
+def check_rechunk(ds: "Dataset"):
+    rechunk = []
+    for key, tensor in ds.tensors.items():
+        if not tensor.meta.sample_compression and not tensor.meta.chunk_compression:
+            engine = tensor.chunk_engine
+            num_chunks = engine.num_chunks
+            if num_chunks > 1:
+                num_samples = engine.num_samples
+                max_shape = tensor.meta.max_shape
+                nbytes = (
+                    np.prod([num_samples] + max_shape) * np.dtype(tensor.dtype).itemsize
+                )
+                avg_chunk_size = nbytes / num_chunks
+
+                if avg_chunk_size < 0.1 * engine.min_chunk_size:
+                    rechunk.append(key)
+    return rechunk

--- a/deeplake/util/check_rechunk.py
+++ b/deeplake/util/check_rechunk.py
@@ -11,11 +11,13 @@ def check_rechunk(ds: "Dataset"):
             if num_chunks > 1:
                 num_samples = engine.num_samples
                 max_shape = tensor.meta.max_shape
-                nbytes = (
-                    np.prod([num_samples] + max_shape) * np.dtype(tensor.dtype).itemsize
-                )
-                avg_chunk_size = nbytes / num_chunks
+                if len(max_shape) > 0:
+                    nbytes = (
+                        np.prod([num_samples] + max_shape)
+                        * np.dtype(tensor.dtype).itemsize
+                    )
+                    avg_chunk_size = nbytes / num_chunks
 
-                if avg_chunk_size < 0.1 * engine.min_chunk_size:
-                    rechunk.append(key)
+                    if avg_chunk_size < 0.1 * engine.min_chunk_size:
+                        rechunk.append(key)
     return rechunk

--- a/deeplake/util/class_label.py
+++ b/deeplake/util/class_label.py
@@ -124,7 +124,7 @@ def sync_labels(
                     progressbar=True,
                     check_lengths=False,
                     skip_ok=True,
-                    disable_rechunk_check=True,
+                    disable_rechunk=True,
                 )
                 target_tensor.meta._disable_temp_transform = False
             finally:

--- a/deeplake/util/class_label.py
+++ b/deeplake/util/class_label.py
@@ -124,6 +124,7 @@ def sync_labels(
                     progressbar=True,
                     check_lengths=False,
                     skip_ok=True,
+                    disable_rechunk_check=True,
                 )
                 target_tensor.meta._disable_temp_transform = False
             finally:

--- a/deeplake/util/encoder.py
+++ b/deeplake/util/encoder.py
@@ -23,11 +23,18 @@ import posixpath
 
 
 def merge_all_meta_info(
-    target_ds, storage, generated_tensors, overwrite, all_num_samples, result
+    target_ds,
+    storage,
+    generated_tensors,
+    overwrite,
+    all_num_samples,
+    result,
+    update_commit_diff=True,
 ):
-    merge_all_commit_diffs(
-        result["commit_diffs"], target_ds, storage, overwrite, generated_tensors
-    )
+    if update_commit_diff:
+        merge_all_commit_diffs(
+            result["commit_diffs"], target_ds, storage, overwrite, generated_tensors
+        )
     merge_all_tile_encoders(
         result["tile_encoders"],
         all_num_samples,

--- a/deeplake/util/transform.py
+++ b/deeplake/util/transform.py
@@ -483,7 +483,6 @@ def delete_overwritten_chunks(old_chunk_paths, storage, overwrite):
     if not overwrite:
         return
 
-    print(old_chunk_paths)
     storage.delete_multiple(old_chunk_paths)
 
 

--- a/deeplake/util/transform.py
+++ b/deeplake/util/transform.py
@@ -483,6 +483,7 @@ def delete_overwritten_chunks(old_chunk_paths, storage, overwrite):
     if not overwrite:
         return
 
+    print(old_chunk_paths)
     storage.delete_multiple(old_chunk_paths)
 
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
- Automatically rechunk uncompressed tensors at end of transform if average chunk size is too low
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->