### PR TITLE
[BUGFIX] Fix PIL decode method with multiple workers and shuffling

### DIFF
--- a/deeplake/api/tests/test_api.py
+++ b/deeplake/api/tests/test_api.py
@@ -590,7 +590,7 @@ def test_htype(memory_ds: Dataset):
     label.append(np.array(5, dtype=np.uint32))
     with pytest.raises(NotImplementedError):
         video.append(np.ones((10, 28, 28, 3), dtype=np.uint8))
-    bin_mask.append(np.zeros((28, 28), dtype=np.bool8))
+    bin_mask.append(np.zeros((28, 28), dtype=bool))
     segment_mask.append(np.ones((28, 28), dtype=np.uint32))
     keypoints_coco.append(np.ones((51, 2), dtype=np.int32))
     point.append(np.ones((11, 2), dtype=np.int32))

--- a/deeplake/integrations/pytorch/shuffle_buffer.py
+++ b/deeplake/integrations/pytorch/shuffle_buffer.py
@@ -5,7 +5,7 @@ from operator import mul
 import warnings
 import numpy as np
 import torch
-from PIL import Image
+from PIL import Image  # type: ignore
 from io import BytesIO
 from tqdm import tqdm  # type: ignore
 

--- a/deeplake/integrations/pytorch/shuffle_buffer.py
+++ b/deeplake/integrations/pytorch/shuffle_buffer.py
@@ -5,6 +5,8 @@ from operator import mul
 import warnings
 import numpy as np
 import torch
+from PIL import Image
+from io import BytesIO
 from tqdm import tqdm  # type: ignore
 
 
@@ -106,8 +108,12 @@ class ShuffleBuffer:
             return sample.element_size() * reduce(mul, sample.shape, 1)
         elif isinstance(sample, np.ndarray):
             return sample.nbytes
+        elif isinstance(sample, Image.Image):
+            img = BytesIO()
+            sample.save(img, sample.format)
+            return len(img.getvalue())
         raise ValueError(
-            f"Expected input of type bytes, dict, Sequence, torch.Tensor or np.ndarray, got: {type(sample)}"
+            f"Expected input of type bytes, dict, Sequence, torch.Tensor, np.ndarray or PIL image, got: {type(sample)}"
         )
 
     def __len__(self):

--- a/deeplake/integrations/tests/test_pytorch.py
+++ b/deeplake/integrations/tests/test_pytorch.py
@@ -688,6 +688,34 @@ def test_pytorch_decode(ds, compressed_image_paths, compression):
 
 
 @requires_torch
+def test_pytorch_decode_multi_worker_shuffle(local_ds, compressed_image_paths):
+    with local_ds as ds:
+        ds.create_tensor("image", sample_compression="jpeg")
+        ds.image.extend(
+            np.array([i * np.ones((10, 10, 3), dtype=np.uint8) for i in range(5)])
+        )
+        ds.image.extend([deeplake.read(compressed_image_paths["jpeg"][0])] * 5)
+        for i, batch in enumerate(
+            ds.pytorch(
+                num_workers=2,
+                shuffle=True,
+                decode_method={"image": "pil"},
+                collate_fn=identity,
+            )
+        ):
+            image = batch[0]["image"]
+            index = batch[0]["index"][0]
+            assert isinstance(image, Image.Image)
+            if i < 5:
+                np.testing.assert_array_equal(
+                    np.array(image), i * np.ones((10, 10, 3), dtype=np.uint8)
+                )
+            elif i >= 5:
+                with Image.open(compressed_image_paths["jpeg"][index]) as f:
+                    np.testing.assert_array_equal(np.array(f), np.array(image))
+
+
+@requires_torch
 def test_rename(local_ds):
     with local_ds as ds:
         ds.create_tensor("abc")

--- a/deeplake/integrations/tests/test_pytorch.py
+++ b/deeplake/integrations/tests/test_pytorch.py
@@ -706,12 +706,12 @@ def test_pytorch_decode_multi_worker_shuffle(local_ds, compressed_image_paths):
             image = batch[0]["image"]
             index = batch[0]["index"][0]
             assert isinstance(image, Image.Image)
-            if i < 5:
+            if index < 5:
                 np.testing.assert_array_equal(
-                    np.array(image), i * np.ones((10, 10, 3), dtype=np.uint8)
+                    np.array(image), index * np.ones((10, 10, 3), dtype=np.uint8)
                 )
-            elif i >= 5:
-                with Image.open(compressed_image_paths["jpeg"][index]) as f:
+            elif index >= 5:
+                with Image.open(compressed_image_paths["jpeg"][0]) as f:
                     np.testing.assert_array_equal(np.array(f), np.array(image))
 
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->