### PR TITLE
[AL-2094] Switch to S3 link for nifti cloud test

### DIFF
--- a/deeplake/api/tests/test_nifti.py
+++ b/deeplake/api/tests/test_nifti.py
@@ -101,10 +101,17 @@ def test_nifti_cloud(memory_ds, s3_root_storage):
         s3_root_storage["example4d.nii.gz"] = data
 
         ds.create_tensor("abc", htype="nifti", sample_compression="nii.gz")
+        ds.create_tensor(
+            "nifti_linked", htype="link[nifti]", sample_compression="nii.gz"
+        )
         ds.abc.append(
             deeplake.read(f"{s3_root_storage.root}/example4d.nii.gz", verify=True)
         )
+        ds.nifti_linked.append(
+            deeplake.link(f"{s3_root_storage.root}/example4d.nii.gz")
+        )
 
         assert ds.abc[0].numpy().shape == img.shape
+        assert ds.nifti_linked[0].numpy().shape == img.shape
 
         del s3_root_storage["example4d.nii.gz"]

--- a/deeplake/core/linked_sample.py
+++ b/deeplake/core/linked_sample.py
@@ -20,8 +20,9 @@ class LinkedSample:
         self.path = path
         self.creds_key = convert_creds_key(creds_key, path)
 
+    @property
     def dtype(self) -> str:
-        return np.array("").dtype.name
+        return np.array("").dtype.str
 
 
 def read_linked_sample(

--- a/deeplake/tests/storage_fixtures.py
+++ b/deeplake/tests/storage_fixtures.py
@@ -67,7 +67,7 @@ def gcs_storage(gcs_path):
 
 @pytest.fixture
 def s3_root_storage(request):
-    if not is_opt_true(request, GCS_OPT):
+    if not is_opt_true(request, S3_OPT):
         pytest.skip()
         return
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
- Use our S3 for nifti cloud test instead of the http link because sometimes it times out
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->