### PR TITLE
Handle images with 0 in shape and grayscale images with shape (h,w,1) in downsampling

### DIFF
--- a/deeplake/core/tensor_link.py
+++ b/deeplake/core/tensor_link.py
@@ -1,4 +1,5 @@
 from typing import Callable
+from deeplake.core.compression import to_image
 from deeplake.core.index import Index
 from deeplake.constants import _NO_LINK_UPDATE
 import inspect
@@ -188,8 +189,12 @@ def convert_sample_for_downsampling(sample, link_creds=None):
         )
     if isinstance(sample, deeplake.core.sample.Sample):
         sample = sample.pil
-    if isinstance(sample, np.ndarray) and sample.dtype != bool:
-        sample = Image.fromarray(sample)
+    if (
+        isinstance(sample, np.ndarray)
+        and sample.dtype != bool
+        and 0 not in sample.shape
+    ):
+        sample = to_image(sample)
     return sample
 
 

--- a/deeplake/enterprise/dataloader.py
+++ b/deeplake/enterprise/dataloader.py
@@ -155,7 +155,11 @@ class DeepLakeDataLoader(DataLoader):
 
     @property
     def sampler(self):
-        return DistributedSampler(self.dataset) if self._distributed else _InfiniteConstantSampler()
+        return (
+            DistributedSampler(self.dataset)
+            if self._distributed
+            else _InfiniteConstantSampler()
+        )
 
     @property
     def batch_sampler(self):

--- a/deeplake/util/downsample.py
+++ b/deeplake/util/downsample.py
@@ -28,7 +28,10 @@ def needs_downsampling(sample, factor: int):
     if isinstance(sample, Image.Image):
         dimensions = sample.size
     elif isinstance(sample, np.ndarray):
-        dimensions = sample.shape[:2]
+        dimensions = sample.shape
+        if len(dimensions) == 3 and dimensions[2] == 0:
+            return False
+        dimensions = dimensions[:2]
 
     if dimensions[0] * dimensions[1] <= 100 * factor * factor:
         return False
@@ -64,12 +67,11 @@ def downsample_sample(
         required_dtype = arr.dtype
         return np.ones(required_shape, dtype=required_dtype)
 
-    if isinstance(sample, np.ndarray) and sample.dtype == bool:
+    if isinstance(sample, np.ndarray):
         downsampled_sample = sample[::factor, ::factor]
         return downsampled_sample
-    else:
-        size = sample.size[0] // factor, sample.size[1] // factor
-        downsampled_sample = sample.resize(size, get_filter(htype))
+    size = sample.size[0] // factor, sample.size[1] // factor
+    downsampled_sample = sample.resize(size, get_filter(htype))
     if compression is None:
         return np.array(downsampled_sample)
     with io.BytesIO() as f:


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->