### PR TITLE
[CUS-95] Fix materialization of views with empty tensors

### DIFF
--- a/deeplake/api/tests/test_api.py
+++ b/deeplake/api/tests/test_api.py
@@ -2376,3 +2376,24 @@ def test_pickle_bug(local_ds):
         ds["__temp_123"].numpy()
 
     assert ds._temp_tensors == []
+
+
+def test_extend_with_empty_tensor(memory_ds):
+    with memory_ds as ds:
+        ds.create_tensor("abc")
+        ds.abc.extend([None, None, None])
+
+        ds.create_tensor("xyz")
+        ds.xyz.extend(ds.abc)
+        ds.xyz.extend([ds.abc[0], ds.abc[1]])
+
+        with pytest.raises(EmptyTensorError):
+            ds.xyz.numpy()
+
+        ds.xyz.append(1)
+
+        data = ds.xyz.numpy(aslist=True)
+        expected = [[]] * 5 + [1]
+
+        for i in range(len(data)):
+            np.testing.assert_array_equal(data[i], expected[i])

--- a/deeplake/core/chunk_engine.py
+++ b/deeplake/core/chunk_engine.py
@@ -653,7 +653,16 @@ class ChunkEngine:
     def _sanitize_samples(self, samples, verify=True):
         check_samples_type(samples)
         if isinstance(samples, list):
-            samples = [None if is_empty_list(sample) else sample for sample in samples]
+            samples = [
+                None
+                if is_empty_list(sample)
+                or (
+                    isinstance(sample, deeplake.core.tensor.Tensor)
+                    and sample.is_empty_tensor
+                )
+                else sample
+                for sample in samples
+            ]
         verified_samples = self.check_each_sample(samples, verify=verify)
         tensor_meta = self.tensor_meta
         all_empty = all(sample is None for sample in samples)
@@ -1029,7 +1038,14 @@ class ChunkEngine:
             if link_callback:
                 if not isinstance(verified_samples, np.ndarray):
                     samples = [
-                        None if is_empty_list(s) else s for s in verified_samples
+                        None
+                        if is_empty_list(s)
+                        or (
+                            isinstance(s, deeplake.core.tensor.Tensor)
+                            and s.is_empty_tensor
+                        )
+                        else s
+                        for s in verified_samples
                     ]
                 link_callback(
                     samples,

--- a/deeplake/core/tensor.py
+++ b/deeplake/core/tensor.py
@@ -52,7 +52,11 @@ from deeplake.constants import FIRST_COMMIT_ID, _NO_LINK_UPDATE, UNSPECIFIED
 from deeplake.util.version_control import auto_checkout
 from deeplake.util.video import normalize_index
 
-from deeplake.compression import get_compression_type, VIDEO_COMPRESSION
+from deeplake.compression import (
+    get_compression_type,
+    VIDEO_COMPRESSION,
+    BYTE_COMPRESSION,
+)
 from deeplake.util.notebook import is_jupyter, video_html, is_colab
 from deeplake.util.object_3d.point_cloud import parse_point_cloud_to_dict
 from deeplake.util.object_3d.mesh import (
@@ -713,6 +717,15 @@ class Tensor:
             yield self.__getitem__(
                 i, is_iteration=not isinstance(self.index.values[0], list)
             )
+
+    @property
+    def is_empty_tensor(self):
+        if (
+            self.meta.chunk_compression
+            and get_compression_type(self.meta.chunk_compression) != BYTE_COMPRESSION
+        ):
+            return self.meta.max_shape == [0, 0, 0]
+        return len(self.meta.max_shape) == 0
 
     def numpy(
         self, aslist=False, fetch_chunks=False

--- a/deeplake/core/tensor.py
+++ b/deeplake/core/tensor.py
@@ -720,11 +720,19 @@ class Tensor:
 
     @property
     def is_empty_tensor(self):
+        if self.meta.is_link:
+            if len(self.meta.max_shape) == 0:
+                for chunk in self.chunk_engine.get_chunks_for_sample(0):
+                    if len(chunk.data_bytes) != 0:
+                        return False
+                return True
+            return False
+
         if (
             self.meta.chunk_compression
             and get_compression_type(self.meta.chunk_compression) != BYTE_COMPRESSION
         ):
-            return self.meta.max_shape == [0, 0, 0]
+            return self.meta.max_shape == [0, 0, 0] or len(self.meta.max_shape) == 0
         return len(self.meta.max_shape) == 0
 
     def numpy(


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
- Fix materialization of views with empty tensor
- Fix copying empty tensors: `ds.abc.extend(ds.xyz)` when ds.xyz is full of empty samples
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->