### PR TITLE
Fixes issues with linked tensors when working with datasets containing both rgb and grayscale images

### DIFF
--- a/deeplake/api/tests/test_link.py
+++ b/deeplake/api/tests/test_link.py
@@ -618,3 +618,19 @@ def test_shape_interval(local_ds_generator, cat_path, flower_path, shape_tensor)
         assert ds.img.shape_interval.astuple() == (3, 900, 900, 3)
         ds.img[1] = deeplake.link(flower_path)
         assert ds.img.meta.max_shape == [900, 900, 4]
+
+
+def test_rgb_gray(local_ds, cat_path, hopper_gray_path):
+    with local_ds as ds:
+        ds.create_tensor("abc", "link[image]", sample_compression="jpeg")
+        ds.abc.append(deeplake.link(cat_path))
+        ds.abc.append(deeplake.link(hopper_gray_path))
+
+        assert len(ds.abc.meta.max_shape) == 3
+        assert len(ds.abc.meta.min_shape) == 3
+        assert len(ds.abc[0].shape) == 3
+        assert len(ds.abc[1].shape) == 3
+        assert len(ds.abc[0].numpy().shape) == 3
+
+        # TODO: fix this, .shape should be the same as .numpy().shape
+        assert len(ds.abc[1].numpy().shape) == 2

--- a/deeplake/core/tensor_link.py
+++ b/deeplake/core/tensor_link.py
@@ -115,9 +115,6 @@ def update_shape(new_sample, link_creds=None, tensor_meta=None):
         )
 
     if tensor_meta:
-        if tensor_meta.is_link and ret.size and np.prod(ret):
-            tensor_meta.update_shape_interval(ret.tolist())
-
         # if grayscale being appended but tensor has rgb samples, convert shape from (h, w) to (h, w, 1)
         if (
             tensor_meta.min_shape
@@ -135,6 +132,9 @@ def update_shape(new_sample, link_creds=None, tensor_meta=None):
             and len(tensor_meta.min_shape) == 3
         ):
             ret = np.concatenate([ret, (1,)])
+
+        if tensor_meta.is_link and ret.size and np.prod(ret):
+            tensor_meta.update_shape_interval(ret.tolist())
 
     return ret
 

--- a/deeplake/tests/path_fixtures.py
+++ b/deeplake/tests/path_fixtures.py
@@ -375,6 +375,14 @@ def flower_path():
 
 
 @pytest.fixture
+def hopper_gray_path():
+    """Path to a grayscale hopper image in the dummy data folder. Expected shape: (512, 512)"""
+
+    path = get_dummy_data_path("images")
+    return os.path.join(path, "hopper_gray.jpg")
+
+
+@pytest.fixture
 def color_image_paths():
     base = get_dummy_data_path("images")
     paths = {


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->