### PR TITLE
Automatically rechunk uncompressed tensors at the end of transform

### DIFF
--- a/deeplake/api/tests/test_rechunk.py
+++ b/deeplake/api/tests/test_rechunk.py
@@ -129,7 +129,10 @@ def test_rechunk_text(local_ds_generator):
     with local_ds_generator() as ds:
         ds.create_tensor("abc", "text")
         add_sample_in().eval(
-            ["hello", "world", "abc", "def", "ghi", "yo"], ds, num_workers=2
+            ["hello", "world", "abc", "def", "ghi", "yo"],
+            ds,
+            num_workers=2,
+            disable_rechunk=True,
         )
 
         assert len(ds.abc.chunk_engine.chunk_id_encoder.array) == 2
@@ -152,7 +155,10 @@ def test_rechunk_json(local_ds_generator):
     with local_ds_generator() as ds:
         ds.create_tensor("abc", "json")
         add_sample_in().eval(
-            [{"one": "if"}, {"two": "elif"}, {"three": "else"}], ds, num_workers=2
+            [{"one": "if"}, {"two": "elif"}, {"three": "else"}],
+            ds,
+            num_workers=2,
+            disable_rechunk=True,
         )
 
         assert len(ds.abc.chunk_engine.chunk_id_encoder.array) == 2
@@ -175,7 +181,10 @@ def test_rechunk_list(local_ds_generator):
     with local_ds_generator() as ds:
         ds.create_tensor("abc", "list")
         add_sample_in().eval(
-            [["hello", "world"], ["abc", "def", "ghi"], ["yo"]], ds, num_workers=2
+            [["hello", "world"], ["abc", "def", "ghi"], ["yo"]],
+            ds,
+            num_workers=2,
+            disable_rechunk=True,
         )
 
         assert len(ds.abc.chunk_engine.chunk_id_encoder.array) == 2

--- a/deeplake/constants.py
+++ b/deeplake/constants.py
@@ -165,3 +165,7 @@ SHOW_ITERATION_WARNING = True
 
 # Delay before spinner starts on time consuming functions (in seconds)
 SPINNER_START_DELAY = 2
+
+# Rechunk after transform if average chunk size is less than
+# this fraction of min chunk size
+TRANSFORM_RECHUNK_AVG_SIZE_BOUND = 0.1

--- a/deeplake/core/chunk_engine.py
+++ b/deeplake/core/chunk_engine.py
@@ -1277,9 +1277,9 @@ class ChunkEngine:
         samples_to_move.reverse()
         return samples_to_move
 
-    def _get_chunk_samples(self, chunk) -> List[Sample]:
+    def _get_chunk_samples(self, chunk) -> List[Optional[Sample]]:
         decompress = isinstance(chunk, ChunkCompressedChunk)
-        all_samples_in_chunk: List[Sample] = []
+        all_samples_in_chunk: List[Optional[Sample]] = []
 
         for idx in range(chunk.num_samples):
             sample_data = chunk.read_sample(idx, decompress=decompress)

--- a/deeplake/core/chunk_engine.py
+++ b/deeplake/core/chunk_engine.py
@@ -2524,6 +2524,8 @@ class ChunkEngine:
         num_chunks, num_samples = self.num_chunks, self.num_samples
         max_shape = self.tensor_meta.max_shape
         dtype = self.tensor_meta.dtype
+        if dtype in ("Any", "List", None):
+            return None
         nbytes = np.prod([num_samples] + max_shape) * np.dtype(dtype).itemsize
         avg_chunk_size = nbytes / num_chunks
         return avg_chunk_size

--- a/deeplake/core/chunk_engine.py
+++ b/deeplake/core/chunk_engine.py
@@ -1467,13 +1467,13 @@ class ChunkEngine:
             chunk.num_data_bytes < RANDOM_MINIMAL_CHUNK_SIZE
             and self.max_chunk_size > RANDOM_MINIMAL_CHUNK_SIZE
         ):
-            return self._try_merge_with_neighbor_and_split(chunk=chunk, row=chunk_row)
+            self._try_merge_with_neighbor_and_split(chunk=chunk, row=chunk_row)
 
         elif (
             chunk.num_data_bytes > RANDOM_MAX_ALLOWED_CHUNK_SIZE
             or chunk.num_data_bytes > self.max_chunk_size + RANDOM_MINIMAL_CHUNK_SIZE
         ):
-            return self.__rechunk(chunk, chunk_row)
+            self.__rechunk(chunk, chunk_row)
 
     def _update(
         self,

--- a/deeplake/core/chunk_engine.py
+++ b/deeplake/core/chunk_engine.py
@@ -2519,7 +2519,7 @@ class ChunkEngine:
             and self.active_updated_chunk.key == chunk_key
         ):
             self.active_updated_chunk = None
-    
+
     def get_avg_chunk_size(self):
         num_chunks, num_samples = self.num_chunks, self.num_samples
         max_shape = self.tensor_meta.max_shape

--- a/deeplake/core/chunk_engine.py
+++ b/deeplake/core/chunk_engine.py
@@ -2519,3 +2519,11 @@ class ChunkEngine:
             and self.active_updated_chunk.key == chunk_key
         ):
             self.active_updated_chunk = None
+    
+    def get_avg_chunk_size(self):
+        num_chunks, num_samples = self.num_chunks, self.num_samples
+        max_shape = self.tensor_meta.max_shape
+        dtype = self.tensor_meta.dtype
+        nbytes = np.prod([num_samples] + max_shape) * np.dtype(dtype).itemsize
+        avg_chunk_size = nbytes / num_chunks
+        return avg_chunk_size

--- a/deeplake/core/chunk_engine.py
+++ b/deeplake/core/chunk_engine.py
@@ -1283,7 +1283,11 @@ class ChunkEngine:
 
         for idx in range(chunk.num_samples):
             sample_data = chunk.read_sample(idx, decompress=decompress)
-            sample_shape = chunk.shapes_encoder[idx]
+            try:
+                sample_shape = chunk.shapes_encoder[idx]
+            except IndexError:
+                all_samples_in_chunk.append(None)
+                continue
             new_sample = self._get_sample_object(
                 sample_data, sample_shape, chunk.compression, chunk.dtype, decompress
             )
@@ -1357,7 +1361,7 @@ class ChunkEngine:
             samples,
             start_chunk=to_chunk,
             register=True,
-            update_commit_diff=True,
+            update_commit_diff=False,  # merging chunks should not update diff
             update_tensor_meta=False,
             start_chunk_row=to_chunk_row,
             register_creds=False,

--- a/deeplake/core/chunk_engine.py
+++ b/deeplake/core/chunk_engine.py
@@ -1463,13 +1463,13 @@ class ChunkEngine:
             chunk.num_data_bytes < RANDOM_MINIMAL_CHUNK_SIZE
             and self.max_chunk_size > RANDOM_MINIMAL_CHUNK_SIZE
         ):
-            self._try_merge_with_neighbor_and_split(chunk=chunk, row=chunk_row)
+            return self._try_merge_with_neighbor_and_split(chunk=chunk, row=chunk_row)
 
         elif (
             chunk.num_data_bytes > RANDOM_MAX_ALLOWED_CHUNK_SIZE
             or chunk.num_data_bytes > self.max_chunk_size + RANDOM_MINIMAL_CHUNK_SIZE
         ):
-            self.__rechunk(chunk, chunk_row)
+            return self.__rechunk(chunk, chunk_row)
 
     def _update(
         self,

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -2464,6 +2464,7 @@ class Dataset:
             skip_ok=True,
             extend_only=True,
             disable_label_sync=True,
+            disable_rechunk=True,
         )
 
     # the below methods are used by cloudpickle dumps

--- a/deeplake/core/storage/google_drive.py
+++ b/deeplake/core/storage/google_drive.py
@@ -367,3 +367,10 @@ class GDriveProvider(StorageProvider):
                     pass
         if not prefix:
             self._delete_file(self.root_id)
+
+    def get_object_size(self, key: str) -> int:
+        id = self._get_id(key)
+        if not id:
+            raise KeyError(key)
+        size = int(self.drive.files().get(fileId=id, fields="size").execute()["size"])
+        return size

--- a/deeplake/core/tests/test_locking.py
+++ b/deeplake/core/tests/test_locking.py
@@ -27,7 +27,7 @@ class VM(object):
 
     def __enter__(self):
         self._getnode = uuid.getnode
-        uuid.getnode = lambda: self.id
+        uuid.getnode = lambda: self.id  # type: ignore
         self._locks = deeplake.core.lock._LOCKS.copy()
         deeplake.core.lock._LOCKS.clear()
 

--- a/deeplake/core/transform/test_transform.py
+++ b/deeplake/core/transform/test_transform.py
@@ -335,7 +335,8 @@ def test_chain_transform_list_small(local_ds, scheduler):
     for i in range(100):
         for index in range(6 * i, 6 * i + 6):
             np.testing.assert_array_equal(
-                ds_out[index].image.numpy(), 15 * i * np.ones((337, 200))
+                ds_out[index].image.numpy(),
+                np.asarray(15 * i * np.ones((337, 200)), dtype=np.uint8),
             )
             np.testing.assert_array_equal(
                 ds_out[index].label.numpy(), 15 * i * np.ones((1,))
@@ -396,7 +397,8 @@ def test_add_to_non_empty_dataset(local_ds, scheduler, do_commit):
     for i in range(100):
         for index in range(10 + 6 * i, 10 + 6 * i + 6):
             np.testing.assert_array_equal(
-                ds_out[index].image.numpy(), 15 * i * np.ones((337, 200))
+                ds_out[index].image.numpy(),
+                np.asarray(15 * i * np.ones((337, 200)), dtype=np.uint8),
             )
             np.testing.assert_array_equal(
                 ds_out[index].label.numpy(), 15 * i * np.ones((1,))
@@ -912,7 +914,7 @@ def test_transform_skip_ok(local_ds_generator):
     for i in range(100):
         for index in range(6 * i, 6 * i + 6):
             np.testing.assert_array_equal(
-                ds.image[index].numpy(), 15 * i * np.ones((337, 200))
+                ds.image[index].numpy(), np.asarray(15 * i * np.ones((337, 200)), dtype=np.uint8)
             )
             np.testing.assert_array_equal(
                 ds.label[index].numpy(), 15 * i * np.ones((1,))
@@ -925,7 +927,7 @@ def test_transform_skip_ok(local_ds_generator):
     for i in range(100):
         for index in range(6 * i, 6 * i + 6):
             np.testing.assert_array_equal(
-                ds.image[index].numpy(), 15 * i * np.ones((337, 200))
+                ds.image[index].numpy(), np.asarray(15 * i * np.ones((337, 200)), dtype=np.uint8)
             )
             np.testing.assert_array_equal(
                 ds.label[index].numpy(), 15 * i * np.ones((1,))

--- a/deeplake/core/transform/test_transform.py
+++ b/deeplake/core/transform/test_transform.py
@@ -914,7 +914,8 @@ def test_transform_skip_ok(local_ds_generator):
     for i in range(100):
         for index in range(6 * i, 6 * i + 6):
             np.testing.assert_array_equal(
-                ds.image[index].numpy(), np.asarray(15 * i * np.ones((337, 200)), dtype=np.uint8)
+                ds.image[index].numpy(),
+                np.asarray(15 * i * np.ones((337, 200)), dtype=np.uint8),
             )
             np.testing.assert_array_equal(
                 ds.label[index].numpy(), 15 * i * np.ones((1,))
@@ -927,7 +928,8 @@ def test_transform_skip_ok(local_ds_generator):
     for i in range(100):
         for index in range(6 * i, 6 * i + 6):
             np.testing.assert_array_equal(
-                ds.image[index].numpy(), np.asarray(15 * i * np.ones((337, 200)), dtype=np.uint8)
+                ds.image[index].numpy(),
+                np.asarray(15 * i * np.ones((337, 200)), dtype=np.uint8),
             )
             np.testing.assert_array_equal(
                 ds.label[index].numpy(), 15 * i * np.ones((1,))

--- a/deeplake/core/transform/transform.py
+++ b/deeplake/core/transform/transform.py
@@ -241,11 +241,13 @@ class Pipeline:
                 load_meta(original_data_in)
                 if pad_data_in and not initial_padding_state:
                     original_data_in._disable_padding()
-                rechunk_if_necessary(original_data_in)
+                if not kwargs.get("disable_rechunk"):
+                    rechunk_if_necessary(original_data_in)
             else:
                 load_meta(target_ds)
                 target_ds.storage.autoflush = initial_autoflush
-                rechunk_if_necessary(target_ds)
+                if not kwargs.get("disable_rechunk"):
+                    rechunk_if_necessary(target_ds)
 
     def run(
         self,

--- a/deeplake/core/transform/transform.py
+++ b/deeplake/core/transform/transform.py
@@ -241,14 +241,10 @@ class Pipeline:
                 load_meta(original_data_in)
                 if pad_data_in and not initial_padding_state:
                     original_data_in._disable_padding()
+                rechunk_if_necessary(original_data_in)
             else:
                 load_meta(target_ds)
                 target_ds.storage.autoflush = initial_autoflush
-            if not target_ds.read_only:
-                target_ds.img.chunk_engine.chunk_id_encoder.is_dirty = True
-                target_ds.flush()
-                print(target_ds.img.chunk_engine.num_chunks)
-            if not kwargs.get("disable_rechunk"):
                 rechunk_if_necessary(target_ds)
 
     def run(

--- a/deeplake/core/transform/transform.py
+++ b/deeplake/core/transform/transform.py
@@ -244,6 +244,12 @@ class Pipeline:
             else:
                 load_meta(target_ds)
                 target_ds.storage.autoflush = initial_autoflush
+            if not target_ds.read_only:
+                target_ds.img.chunk_engine.chunk_id_encoder.is_dirty = True
+                target_ds.flush()
+                print(target_ds.img.chunk_engine.num_chunks)
+            if not kwargs.get("disable_rechunk"):
+                rechunk_if_necessary(target_ds)
 
     def run(
         self,
@@ -376,9 +382,6 @@ class Pipeline:
                 scheduler=scheduler,
                 verbose=progressbar,
             )
-
-        if not kwargs.get("disable_rechunk"):
-            rechunk_if_necessary(target_ds, generated_tensors)
 
 
 def compose(functions: List[ComputeFunction]):  # noqa: DAR101, DAR102, DAR201, DAR401

--- a/deeplake/core/transform/transform.py
+++ b/deeplake/core/transform/transform.py
@@ -24,6 +24,7 @@ from deeplake.util.transform import (
     sanitize_workers_scheduler,
     store_data_slice,
     store_data_slice_with_pbar,
+    rechunk_if_necessary,
 )
 from deeplake.util.encoder import merge_all_meta_info
 from deeplake.util.exceptions import (
@@ -375,6 +376,9 @@ class Pipeline:
                 scheduler=scheduler,
                 verbose=progressbar,
             )
+
+        if not kwargs.get("disable_rechunk"):
+            rechunk_if_necessary(target_ds, generated_tensors)
 
 
 def compose(functions: List[ComputeFunction]):  # noqa: DAR101, DAR102, DAR201, DAR401

--- a/deeplake/util/transform.py
+++ b/deeplake/util/transform.py
@@ -557,8 +557,8 @@ def rechunk_if_necessary(ds):
                     if len(max_shape) > 0:
                         avg_chunk_size = engine.get_avg_chunk_size()
                         if (
-                            avg_chunk_size is not None and
-                            avg_chunk_size
+                            avg_chunk_size is not None
+                            and avg_chunk_size
                             < TRANSFORM_RECHUNK_AVG_SIZE_BOUND * engine.min_chunk_size
                         ):
                             enc = tensor.chunk_engine.chunk_id_encoder

--- a/deeplake/util/transform.py
+++ b/deeplake/util/transform.py
@@ -564,9 +564,13 @@ def rechunk_if_necessary(ds):
                             while True:
                                 encoded = enc._encoded
                                 for row, chunk_id in enumerate(encoded[:, 0]):
-                                    engine._check_rechunk(
-                                        engine.get_chunk_from_chunk_id(chunk_id), row
-                                    )
+                                    try:
+                                        engine._check_rechunk(
+                                            engine.get_chunk_from_chunk_id(chunk_id), row
+                                        )
+                                    # not supported on gdrive
+                                    except NotImplementedError:
+                                        break
                                     rechunked = len(encoded) != len(enc._encoded)
                                     if rechunked:
                                         break

--- a/deeplake/util/transform.py
+++ b/deeplake/util/transform.py
@@ -541,12 +541,6 @@ def process_transform_result(result: List[Dict]):
     return final
 
 
-def _get_avg_chunk_size(num_samples, max_shape, num_chunks, dtype):
-    nbytes = np.prod([num_samples] + max_shape) * np.dtype(dtype).itemsize
-    avg_chunk_size = nbytes / num_chunks
-    return avg_chunk_size
-
-
 def rechunk_if_necessary(ds):
     with ds:
         for tensor in ds.tensors:
@@ -559,12 +553,9 @@ def rechunk_if_necessary(ds):
                 engine = tensor.chunk_engine
                 num_chunks = engine.num_chunks
                 if num_chunks > 1:
-                    num_samples = engine.num_samples
                     max_shape = tensor.meta.max_shape
                     if len(max_shape) > 0:
-                        avg_chunk_size = _get_avg_chunk_size(
-                            num_samples, max_shape, num_chunks, tensor.dtype
-                        )
+                        avg_chunk_size = engine.get_avg_chunk_size()
                         if (
                             avg_chunk_size
                             < TRANSFORM_RECHUNK_AVG_SIZE_BOUND * engine.min_chunk_size

--- a/deeplake/util/transform.py
+++ b/deeplake/util/transform.py
@@ -557,6 +557,7 @@ def rechunk_if_necessary(ds):
                     if len(max_shape) > 0:
                         avg_chunk_size = engine.get_avg_chunk_size()
                         if (
+                            avg_chunk_size is not None and
                             avg_chunk_size
                             < TRANSFORM_RECHUNK_AVG_SIZE_BOUND * engine.min_chunk_size
                         ):

--- a/deeplake/util/transform.py
+++ b/deeplake/util/transform.py
@@ -537,37 +537,40 @@ def process_transform_result(result: List[Dict]):
     return final
 
 
-def rechunk_if_necessary(ds, tensors):
-    for tensor in tensors:
-        try:
-            tensor = ds[tensor]
-        except TensorDoesNotExistError:
-            continue
-        if not tensor.meta.sample_compression and not tensor.meta.chunk_compression:
-            engine = tensor.chunk_engine
-            num_chunks = engine.num_chunks
-            if num_chunks > 1:
-                num_samples = engine.num_samples
-                max_shape = tensor.meta.max_shape
-                if len(max_shape) > 0:
-                    nbytes = (
-                        np.prod([num_samples] + max_shape)
-                        * np.dtype(tensor.dtype).itemsize
-                    )
-                    avg_chunk_size = nbytes / num_chunks
+def rechunk_if_necessary(ds):
+    with ds:
+        for tensor in ds.tensors:
+            try:
+                tensor = ds[tensor]
+            # temp tensors
+            except TensorDoesNotExistError:
+                continue
+            if not tensor.meta.sample_compression and not tensor.meta.chunk_compression:
+                engine = tensor.chunk_engine
+                num_chunks = engine.num_chunks
+                if num_chunks > 1:
+                    num_samples = engine.num_samples
+                    max_shape = tensor.meta.max_shape
+                    if len(max_shape) > 0:
+                        nbytes = (
+                            np.prod([num_samples] + max_shape)
+                            * np.dtype(tensor.dtype).itemsize
+                        )
+                        avg_chunk_size = nbytes / num_chunks
 
-                    if avg_chunk_size < 0.1 * engine.min_chunk_size:
-                        enc = tensor.chunk_engine.chunk_id_encoder
-                        rechunked = False
-                        while True:
-                            encoded = enc._encoded
-                            for row, chunk_id in enumerate(encoded[:, 0]):
-                                engine._check_rechunk(
-                                    engine.get_chunk_from_chunk_id(chunk_id), row
-                                )
-                                rechunked = len(encoded) != len(enc._encoded)
+                        if avg_chunk_size < 0.1 * engine.min_chunk_size:
+                            enc = tensor.chunk_engine.chunk_id_encoder
+                            print(enc._encoded)
+                            rechunked = False
+                            while True:
+                                encoded = enc._encoded
+                                for row, chunk_id in enumerate(encoded[:, 0]):
+                                    engine._check_rechunk(
+                                        engine.get_chunk_from_chunk_id(chunk_id), row
+                                    )
+                                    rechunked = len(encoded) != len(enc._encoded)
+                                    if rechunked:
+                                        break
                                 if rechunked:
-                                    break
-                            if rechunked:
-                                continue
-                            break
+                                    continue
+                                break

--- a/deeplake/util/transform.py
+++ b/deeplake/util/transform.py
@@ -566,7 +566,8 @@ def rechunk_if_necessary(ds):
                                 for row, chunk_id in enumerate(encoded[:, 0]):
                                     try:
                                         engine._check_rechunk(
-                                            engine.get_chunk_from_chunk_id(chunk_id), row
+                                            engine.get_chunk_from_chunk_id(chunk_id),
+                                            row,
                                         )
                                     # not supported on gdrive
                                     except NotImplementedError:

--- a/deeplake/util/transform.py
+++ b/deeplake/util/transform.py
@@ -560,7 +560,6 @@ def rechunk_if_necessary(ds):
 
                         if avg_chunk_size < 0.1 * engine.min_chunk_size:
                             enc = tensor.chunk_engine.chunk_id_encoder
-                            print(enc._encoded)
                             rechunked = False
                             while True:
                                 encoded = enc._encoded


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
- Automatically rechunk uncompressed tensors at the end of transform
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->