### PR TITLE
Load VDS in same read_only mode as parent 

### DIFF
--- a/deeplake/api/tests/test_views.py
+++ b/deeplake/api/tests/test_views.py
@@ -103,3 +103,20 @@ def test_view_with_empty_tensor(local_ds):
     np.testing.assert_array_equal(
         view.images.numpy(), np.array([1, 2, 3]).reshape(3, 1)
     )
+
+
+def test_vds_read_only(hub_cloud_path, hub_cloud_dev_token):
+    ds = deeplake.empty(hub_cloud_path, token=hub_cloud_dev_token)
+    with ds:
+        ds.create_tensor("abc")
+        ds.abc.extend([1, 2, 3, 4, 5])
+        ds.commit()
+
+    ds[:3].save_view(id="first_3")
+
+    ds = deeplake.load(hub_cloud_path, read_only=True, token=hub_cloud_dev_token)
+
+    view = ds.load_view("first_3")
+
+    assert view.base_storage.read_only == True
+    assert view._vds.base_storage.read_only == True

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -3201,7 +3201,7 @@ class Dataset:
         Note:
             Virtual datasets are returned as such, they are not converted to views.
         """
-        sub_storage = self.base_storage.subdir(path)
+        sub_storage = self.base_storage.subdir(path, read_only=read_only)
 
         if empty:
             sub_storage.clear()

--- a/deeplake/core/dataset/view_entry.py
+++ b/deeplake/core/dataset/view_entry.py
@@ -56,6 +56,7 @@ class ViewEntry:
             lock=False,
             verbose=False,
             token=self._src_ds.token,
+            read_only=True,
         )
         sub_ds_path = ds.path
         if self.virtual:

--- a/deeplake/core/storage/gcs.py
+++ b/deeplake/core/storage/gcs.py
@@ -272,7 +272,7 @@ class GCSProvider(StorageProvider):
         self._presigned_urls: Dict[str, Tuple[str, float]] = {}
         self.expiration: Optional[str] = None
 
-    def subdir(self, path: str, read_only: bool):
+    def subdir(self, path: str, read_only: bool = False):
         sd = self.__class__(
             root=posixpath.join(self.root, path),
             token=self.token,

--- a/deeplake/core/storage/gcs.py
+++ b/deeplake/core/storage/gcs.py
@@ -272,7 +272,7 @@ class GCSProvider(StorageProvider):
         self._presigned_urls: Dict[str, Tuple[str, float]] = {}
         self.expiration: Optional[str] = None
 
-    def subdir(self, path: str):
+    def subdir(self, path: str, read_only: bool):
         sd = self.__class__(
             root=posixpath.join(self.root, path),
             token=self.token,
@@ -280,6 +280,7 @@ class GCSProvider(StorageProvider):
         )
         if self.expiration:
             sd._set_hub_creds_info(self.hub_path, self.expiration)
+        sd.read_only = read_only
         return sd
 
     def _initialize_provider(self):

--- a/deeplake/core/storage/local.py
+++ b/deeplake/core/storage/local.py
@@ -34,7 +34,7 @@ class LocalProvider(StorageProvider):
         self.files: Optional[Set[str]] = None
         self._all_keys()
 
-    def subdir(self, path: str, read_only: bool):
+    def subdir(self, path: str, read_only: bool = False):
         sd = self.__class__(os.path.join(self.root, path))
         sd.read_only = read_only
         return sd

--- a/deeplake/core/storage/local.py
+++ b/deeplake/core/storage/local.py
@@ -34,8 +34,10 @@ class LocalProvider(StorageProvider):
         self.files: Optional[Set[str]] = None
         self._all_keys()
 
-    def subdir(self, path: str):
-        return self.__class__(os.path.join(self.root, path))
+    def subdir(self, path: str, read_only: bool):
+        sd = self.__class__(os.path.join(self.root, path))
+        sd.read_only = read_only
+        return sd
 
     def __getitem__(self, path: str):
         """Gets the object present at the path within the given byte range.

--- a/deeplake/core/storage/s3.py
+++ b/deeplake/core/storage/s3.py
@@ -114,7 +114,7 @@ class S3Provider(StorageProvider):
         self._initialize_s3_parameters()
         self._presigned_urls: Dict[str, Tuple[str, float]] = {}
 
-    def subdir(self, path: str):
+    def subdir(self, path: str, read_only: bool):
         sd = self.__class__(
             root=posixpath.join(self.root, path),
             aws_access_key_id=self.aws_access_key_id,
@@ -125,6 +125,7 @@ class S3Provider(StorageProvider):
         )
         if self.expiration:
             sd._set_hub_creds_info(self.hub_path, self.expiration)  # type: ignore
+        sd.read_only = read_only
         return sd
 
     def _set(self, path, content):

--- a/deeplake/core/storage/s3.py
+++ b/deeplake/core/storage/s3.py
@@ -114,7 +114,7 @@ class S3Provider(StorageProvider):
         self._initialize_s3_parameters()
         self._presigned_urls: Dict[str, Tuple[str, float]] = {}
 
-    def subdir(self, path: str, read_only: bool):
+    def subdir(self, path: str, read_only: bool = False):
         sd = self.__class__(
             root=posixpath.join(self.root, path),
             aws_access_key_id=self.aws_access_key_id,

--- a/deeplake/core/tests/test_locking.py
+++ b/deeplake/core/tests/test_locking.py
@@ -27,7 +27,7 @@ class VM(object):
 
     def __enter__(self):
         self._getnode = uuid.getnode
-        uuid.getnode = lambda: self.id
+        uuid.getnode = lambda: self.id  # type: ignore
         self._locks = deeplake.core.lock._LOCKS.copy()
         deeplake.core.lock._LOCKS.clear()
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
- Currently, VDS is loaded in write mode whenever possible. It should have same write mode as parent.
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->