### PR TITLE
Disabling summary for views

### DIFF
--- a/deeplake/api/tests/test_api.py
+++ b/deeplake/api/tests/test_api.py
@@ -207,11 +207,15 @@ def test_stringify(memory_ds, capsys):
         capsys.readouterr().out
         == "Dataset(path='mem://hub_pytest/test_api/test_stringify', tensors=['image'])\n\n tensor    htype    shape    dtype  compression\n -------  -------  -------  -------  ------- \n  image   generic  (4, 4)    None     None   \n"
     )
-    ds[1:2].summary()
-    assert (
-        capsys.readouterr().out
-        == "Dataset(path='mem://hub_pytest/test_api/test_stringify', index=Index([slice(1, 2, None)]), tensors=['image'])\n\n tensor    htype    shape    dtype  compression\n -------  -------  -------  -------  ------- \n  image   generic  (1, 4)    None     None   \n"
-    )
+    with pytest.raises(NotImplementedError):
+        ds[1:2].summary()
+    # TODO - Bring this back after summary is supported for views
+    # ds[1:2].summary()
+    # assert (
+    #     capsys.readouterr().out
+    #     == "Dataset(path='mem://hub_pytest/test_api/test_stringify', index=Index([slice(1, 2, None)]), tensors=['image'])\n\n tensor    htype    shape    dtype  compression\n -------  -------  -------  -------  ------- \n  image   generic  (1, 4)    None     None   \n"
+    # )
+
     ds.image.summary()
     assert (
         capsys.readouterr().out

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -2214,6 +2214,10 @@ class Dataset:
 
     def summary(self):
         """Prints a summary of the dataset."""
+
+        if self.is_view:
+            raise NotImplementedError("Summary is not currently supported for views.")
+
         pretty_print = summary_dataset(self)
 
         print(self)


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

--Temporarily disabling summary for views, because it does not work properly in some cases