### PR TITLE
[AL-2229] Images always 3D

### DIFF
--- a/deeplake/api/tests/test_api_with_compression.py
+++ b/deeplake/api/tests/test_api_with_compression.py
@@ -337,13 +337,13 @@ def test_forced_htypes(
             ds.create_tensor("abc", htype="image.gray")
 
     for sample in gray:
-        assert len(sample.shape) == 2
+        assert len(sample.shape) == 3
 
     for sample in rgb:
         assert len(sample.shape) == 3
 
     for sample in gray_png:
-        assert len(sample.shape) == 2
+        assert len(sample.shape) == 3
 
     for sample in rgb_png:
         assert len(sample.shape) == 3

--- a/deeplake/api/tests/test_grayscale.py
+++ b/deeplake/api/tests/test_grayscale.py
@@ -67,7 +67,6 @@ def test_extend_grayscale_second(local_ds_generator, deeplake_read_images):
     assert ds.images.meta.max_shape[-1] == 3
 
 
-@pytest.mark.xfail(raises=SampleAppendError, strict=True)
 def test_append_grayscale_first(local_ds_generator, deeplake_read_images):
     "Append a gray first, color second."
     ds = local_ds_generator()
@@ -102,12 +101,11 @@ def test_append_two_grayscale(local_ds_generator, deeplake_read_images):
     imgtype, gray, _ = deeplake_read_images
     make_tensor_and_append(ds, "image", imgtype, [gray, gray])
     assert len(ds.images) == 2
-    assert ds.images._sample_shape_tensor.shape == (2, 2)
+    assert ds.images._sample_shape_tensor.shape == (2, 3)
     for i in range(2):
         assert ds.images[i].numpy().shape == ds.images[i].shape
-    assert len(ds.images.meta.min_shape) == 2
-    assert list(ds.images.meta.min_shape) == list(gray.shape)
-    assert list(ds.images.meta.max_shape) == list(gray.shape)
+    assert list(ds.images.meta.min_shape) == list(gray.shape) + [1]
+    assert list(ds.images.meta.max_shape) == list(gray.shape) + [1]
 
 
 def test_append_many_grayscale(local_ds_generator, deeplake_read_images):
@@ -116,9 +114,8 @@ def test_append_many_grayscale(local_ds_generator, deeplake_read_images):
     imgtype, gray, _ = deeplake_read_images
     make_tensor_and_append(ds, "image", imgtype, [gray, gray, gray, gray])
     assert len(ds.images) == 4
-    assert ds.images._sample_shape_tensor.shape == (4, 2)
+    assert ds.images._sample_shape_tensor.shape == (4, 3)
     for i in range(4):
         assert ds.images[i].numpy().shape == ds.images[i].shape
-    assert len(ds.images.meta.min_shape) == 2
-    assert list(ds.images.meta.min_shape) == list(gray.shape)
-    assert list(ds.images.meta.max_shape) == list(gray.shape)
+    assert list(ds.images.meta.min_shape) == list(gray.shape) + [1]
+    assert list(ds.images.meta.max_shape) == list(gray.shape) + [1]

--- a/deeplake/core/chunk/base_chunk.py
+++ b/deeplake/core/chunk/base_chunk.py
@@ -408,12 +408,13 @@ class BaseChunk(DeepLakeMemoryObject):
 
     def convert_to_rgb(self, shape):
         if shape is not None and self.is_convert_candidate and CONVERT_GRAYSCALE:
+            ndim = len(shape)
             if self.num_dims is None:
-                self.num_dims = len(shape)
-            if len(shape) == 2 and self.num_dims == 3:
+                self.num_dims = max(3, ndim)
+            if ndim < self.num_dims:
                 message = "Grayscale images will be reshaped from (H, W) to (H, W, 1) to match tensor dimensions. This warning will be shown only once."
                 warnings.warn(message)
-                shape += (1,)  # type: ignore[assignment]
+                shape += (1,) * (self.num_dims - ndim)  # type: ignore[assignment]
         return shape
 
     def can_fit_sample(self, sample_nbytes, buffer_nbytes=0):

--- a/deeplake/core/chunk_engine.py
+++ b/deeplake/core/chunk_engine.py
@@ -1207,7 +1207,11 @@ class ChunkEngine:
             chunk.update_sample(local_sample_index, sample)
         else:
             orig_sample = chunk.read_sample(local_sample_index, copy=True)
-            orig_sample[tuple(e.value for e in index.values[1:])] = sample
+            sample = np.array(sample)
+            lhs = orig_sample[tuple(e.value for e in index.values[1:])]
+            if lhs.ndim > sample.ndim:
+                sample = np.expand_dims(sample, tuple(range(sample.ndim, lhs.ndim)))
+            lhs[:] = sample
             chunk.update_sample(local_sample_index, orig_sample)
         if (
             self.active_updated_chunk is not None

--- a/deeplake/core/compression.py
+++ b/deeplake/core/compression.py
@@ -250,6 +250,8 @@ def compress_array(array: np.ndarray, compression: Optional[str]) -> bytes:
     if compression == "apng":
         return _compress_apng(array)
     try:
+        if array.shape == (1, 1, 1):
+            array = array[0]
         img = to_image(array)
         out = BytesIO()
         out._close = out.close  # type: ignore

--- a/deeplake/core/transform/test_transform.py
+++ b/deeplake/core/transform/test_transform.py
@@ -307,14 +307,14 @@ def test_single_transform_deeplake_dataset_htypes(local_ds, num_workers, schedul
     assert len(ds_out) == 99
     for index in range(1, 100):
         np.testing.assert_array_equal(
-            ds_out[index - 1].image.numpy(), 2 * index * np.ones((index, index))
+            ds_out[index - 1].image.numpy(), 2 * index * np.ones((index, index, 1))
         )
         np.testing.assert_array_equal(
             ds_out[index - 1].label.numpy(), 2 * index * np.ones((1,))
         )
 
-    assert ds_out.image.shape_interval.lower == (99, 1, 1)
-    assert ds_out.image.shape_interval.upper == (99, 99, 99)
+    assert ds_out.image.shape_interval.lower == (99, 1, 1, 1)
+    assert ds_out.image.shape_interval.upper == (99, 99, 99, 1)
     data_in.delete()
 
 
@@ -491,14 +491,14 @@ def test_deeplake_like(local_ds, scheduler="threaded"):
         assert len(ds_out) == 99
         for index in range(1, 100):
             np.testing.assert_array_equal(
-                ds_out[index - 1].image.numpy(), 2 * index * np.ones((index, index))
+                ds_out[index - 1].image.numpy(), 2 * index * np.ones((index, index, 1))
             )
             np.testing.assert_array_equal(
                 ds_out[index - 1].label.numpy(), 2 * index * np.ones((1,))
             )
 
-        assert ds_out.image.shape_interval.lower == (99, 1, 1)
-        assert ds_out.image.shape_interval.upper == (99, 99, 99)
+        assert ds_out.image.shape_interval.lower == (99, 1, 1, 1)
+        assert ds_out.image.shape_interval.upper == (99, 99, 99, 1)
 
 
 def test_transform_empty(local_ds):
@@ -581,14 +581,14 @@ def test_transform_persistance(local_ds_generator, num_workers=2, scheduler="thr
         assert len(ds_out) == 99
         for index in range(1, 100):
             np.testing.assert_array_equal(
-                ds_out[index - 1].image.numpy(), 2 * index * np.ones((index, index))
+                ds_out[index - 1].image.numpy(), 2 * index * np.ones((index, index, 1))
             )
             np.testing.assert_array_equal(
                 ds_out[index - 1].label.numpy(), 2 * index * np.ones((1,))
             )
 
-        assert ds_out.image.shape_interval.lower == (99, 1, 1)
-        assert ds_out.image.shape_interval.upper == (99, 99, 99)
+        assert ds_out.image.shape_interval.lower == (99, 1, 1, 1)
+        assert ds_out.image.shape_interval.upper == (99, 99, 99, 1)
 
     test_ds_out()
     ds_out = local_ds_generator()


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

* Images are always 3d, even if first sample is 2d.

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->