### PR TITLE
[AL-2212] Fix wrong data returned in sequences

### DIFF
--- a/deeplake/core/chunk_engine.py
+++ b/deeplake/core/chunk_engine.py
@@ -2279,15 +2279,11 @@ class ChunkEngine:
             return self.get_empty_sample()
         if index.subscriptable_at(0) and index.subscriptable_at(1):
             item_lengths = []
-            item_length = self._sequence_item_length
-            if item_length:
-                item_lengths = [item_length] * self._sequence_length
-            else:
-                for i in index.values[0].indices(self._sequence_length):
-                    item_length = index.length_at(
-                        1, -int(np.subtract(*self.sequence_encoder[i]))
-                    )
-                    item_lengths.append(item_length)
+            for i in index.values[0].indices(self._sequence_length):
+                item_length = index.length_at(
+                    1, -int(np.subtract(*self.sequence_encoder[i]))
+                )
+                item_lengths.append(item_length)
 
             if aslist:
                 ret = []

--- a/deeplake/core/chunk_engine.py
+++ b/deeplake/core/chunk_engine.py
@@ -2278,17 +2278,26 @@ class ChunkEngine:
         if isinstance(arr, np.ndarray) and arr.size == 0:
             return self.get_empty_sample()
         if index.subscriptable_at(0) and index.subscriptable_at(1):
-            if aslist:
-                _item_length = self._sequence_item_length
-                ret = []
+            item_lengths = []
+            item_length = self._sequence_item_length
+            if item_length:
+                item_lengths = [item_length] * self._sequence_length
+            else:
                 for i in index.values[0].indices(self._sequence_length):
-                    item_length = _item_length or index.length_at(
+                    item_length = index.length_at(
                         1, -int(np.subtract(*self.sequence_encoder[i]))
                     )
+                    item_lengths.append(item_length)
+
+            if aslist:
+                ret = []
+                for item_length in item_lengths:
                     ret.append(arr[:item_length])
                     arr = arr[item_length:]
                 return ret
             else:
+                if len(set(item_lengths)) > 1:
+                    raise DynamicTensorNumpyError(self.name, index, "shape")
                 try:
                     return arr.reshape(  # type: ignore
                         index.length_at(0, self._sequence_length), -1, *arr.shape[1:]  # type: ignore


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
- Fix wrong data returned from sequences when number of samples (after flattening) is a multiple of tensor length
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->