### PR TITLE
[AL-2137] Added optional inputs to kp coco

### DIFF
--- a/deeplake/api/tests/test_api.py
+++ b/deeplake/api/tests/test_api.py
@@ -577,11 +577,20 @@ def test_shape_property(memory_ds):
 def test_htype(memory_ds: Dataset):
     image = memory_ds.create_tensor("image", htype="image", sample_compression="png")
     bbox = memory_ds.create_tensor("bbox", htype="bbox")
-    label = memory_ds.create_tensor("label", htype="class_label")
+    label = memory_ds.create_tensor(
+        "label", htype="class_label", class_names=["a", "b", "c", "d", "e", "f"]
+    )
     video = memory_ds.create_tensor("video", htype="video", sample_compression="mkv")
     bin_mask = memory_ds.create_tensor("bin_mask", htype="binary_mask")
-    segment_mask = memory_ds.create_tensor("segment_mask", htype="segment_mask")
-    keypoints_coco = memory_ds.create_tensor("keypoints_coco", htype="keypoints_coco")
+    segment_mask = memory_ds.create_tensor(
+        "segment_mask", htype="segment_mask", class_names=["a", "b", "c"]
+    )
+    keypoints_coco = memory_ds.create_tensor(
+        "keypoints_coco",
+        htype="keypoints_coco",
+        keypoints=["arm", "leg", "torso"],
+        connections=[[0, 2], [1, 2]],
+    )
     point = memory_ds.create_tensor("point", htype="point")
     point_cloud = memory_ds.create_tensor(
         "point_cloud", htype="point_cloud", sample_compression="las"

--- a/deeplake/htype.py
+++ b/deeplake/htype.py
@@ -75,7 +75,15 @@ HTYPE_CONFIGURATIONS: Dict[str, Dict] = {
         "class_names": [],
         "_info": ["class_names"],
     },
-    htype.KEYPOINTS_COCO: {"dtype": "int32"},
+    htype.KEYPOINTS_COCO: {
+        "dtype": "int32",
+        "keypoints": [],
+        "connections": [],
+        "_info": [
+            "keypoints",
+            "connections",
+        ],  # keypoints and connections should be stored in info, not meta
+    },
     htype.POINT: {"dtype": "int32"},
     htype.JSON: {
         "dtype": "Any",


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes
** Added ability to specify `keypoints` and `connections` .info when creating a keypoints coco tensor
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->