### PR TITLE
Catch all exceptions when initializing async libraries

### DIFF
--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -134,7 +134,7 @@ import warnings
 import jwt
 
 
-_LOCKABLE_STORAGES = {S3Provider, GCSProvider, LocalProvider}
+_LOCKABLE_STORAGES = {}
 
 
 class Dataset:

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -134,7 +134,7 @@ import warnings
 import jwt
 
 
-_LOCKABLE_STORAGES = {}
+_LOCKABLE_STORAGES = {S3Provider, GCSProvider, LocalProvider}
 
 
 class Dataset:

--- a/deeplake/core/storage/s3.py
+++ b/deeplake/core/storage/s3.py
@@ -48,7 +48,7 @@ try:
     import nest_asyncio  # type: ignore
 
     nest_asyncio.apply()  # needed to run asyncio in jupyter notebook
-except ImportError:
+except Exception:
     aioboto3 = None  # type: ignore
     asyncio = None  # type: ignore
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
nest_asyncio.apply() fails in certain environments with streamlit. Related thread https://github.com/streamlit/streamlit/issues/744
