### PR TITLE
[AL-2270] Transforms - Error if all samples are skipped +bugfixes

### DIFF
--- a/deeplake/core/transform/test_transform.py
+++ b/deeplake/core/transform/test_transform.py
@@ -11,7 +11,11 @@ from deeplake.core.version_control.test_version_control import (
 )
 from deeplake.util.remove_cache import remove_memory_cache
 from deeplake.util.check_installation import ray_installed
-from deeplake.util.exceptions import AllSamplesSkippedError, InvalidOutputDatasetError, TransformError
+from deeplake.util.exceptions import (
+    AllSamplesSkippedError,
+    InvalidOutputDatasetError,
+    TransformError,
+)
 from deeplake.tests.common import parametrize_num_workers
 from deeplake.util.transform import get_pbar_description
 import deeplake
@@ -1439,6 +1443,7 @@ def test_ds_append_errors(
 
         assert ds["labels"].numpy().shape == (40, 10)
 
+
 def test_all_samples_skipped(local_ds):
     @deeplake.compute
     def upload(stuff, ds):
@@ -1447,14 +1452,20 @@ def test_all_samples_skipped(local_ds):
         else:
             sample = stuff["images"]
         ds.images.append(sample)
-    
+
     with local_ds as ds:
         ds.create_tensor("images", htype="image", sample_compression="png")
-    
-    samples = [{"images": "bad_path"}] * 10 + [{"images": BadSample()}] * 20 + [{"images": "bad_path"}] * 10
+
+    samples = (
+        [{"images": "bad_path"}] * 10
+        + [{"images": BadSample()}] * 20
+        + [{"images": "bad_path"}] * 10
+    )
 
     with pytest.raises(AllSamplesSkippedError) as e:
-        upload().eval(samples, ds, num_workers=TRANSFORM_TEST_NUM_WORKERS, ignore_errors=True)
+        upload().eval(
+            samples, ds, num_workers=TRANSFORM_TEST_NUM_WORKERS, ignore_errors=True
+        )
 
 
 def test_transform_numpy_only(local_ds):

--- a/deeplake/core/transform/transform.py
+++ b/deeplake/core/transform/transform.py
@@ -27,6 +27,7 @@ from deeplake.util.transform import (
 )
 from deeplake.util.encoder import merge_all_meta_info
 from deeplake.util.exceptions import (
+    AllSamplesSkippedError,
     HubComposeEmptyListError,
     HubComposeIncompatibleFunction,
     TransformError,
@@ -296,6 +297,8 @@ class Pipeline:
                 if isinstance(e, TransformError):
                     index, sample = e.index, e.sample
                     e = e.__cause__  # type: ignore
+                if isinstance(e, AllSamplesSkippedError):
+                    raise e
                 raise TransformError(
                     index=index,
                     sample=sample,

--- a/deeplake/util/exceptions.py
+++ b/deeplake/util/exceptions.py
@@ -1050,6 +1050,7 @@ class SampleUpdateError(Exception):
     def __init__(self, key: str):
         super().__init__(f"Unable to update sample in tensor {key}.")
 
+
 class AllSamplesSkippedError(Exception):
     def __init__(self):
         super().__init__(

--- a/deeplake/util/exceptions.py
+++ b/deeplake/util/exceptions.py
@@ -556,7 +556,7 @@ class TransformError(Exception):
             super().__init__(index)
         else:
             print_item = print_path = False
-            if sample:
+            if sample is not None:
                 print_item = is_primitive(sample)
                 print_path = has_path(sample)
 
@@ -580,7 +580,7 @@ class TransformError(Exception):
 class SampleAppendError(Exception):
     def __init__(self, tensor, sample=None):
         print_item = print_path = False
-        if sample:
+        if sample is not None:
             print_item = is_primitive(sample)
             print_path = has_path(sample)
         if print_item or print_path:
@@ -1049,3 +1049,10 @@ class MissingManagedCredsError(Exception):
 class SampleUpdateError(Exception):
     def __init__(self, key: str):
         super().__init__(f"Unable to update sample in tensor {key}.")
+
+class AllSamplesSkippedError(Exception):
+    def __init__(self):
+        super().__init__(
+            "All samples were skipped during the transform. "
+            "Ensure your transform pipeline is correct before you set `ignore_errors=True`."
+        )

--- a/deeplake/util/transform.py
+++ b/deeplake/util/transform.py
@@ -332,6 +332,7 @@ def store_data_slice_with_pbar(pg_callback, transform_input: Tuple) -> Dict:
         cache_size=cache_size,
     )
 
+    ret = True
     if extend_only:
         _extend_data_slice(
             data_slice, offset, transform_dataset, pipeline.functions[0], pg_callback

--- a/deeplake/util/transform.py
+++ b/deeplake/util/transform.py
@@ -217,7 +217,7 @@ def _transform_and_append_data_slice(
                 if not pipeline_checked:
                     _check_pipeline(out, tensors, skip_ok)
                     pipeline_checked = True
-                
+
                 write_sample_to_transform_dataset(out, transform_dataset)
 
             except SampleAppendError as e:
@@ -232,7 +232,7 @@ def _transform_and_append_data_slice(
                     transform_dataset.flush()
                 else:
                     transform_dataset.check_flush()
-            
+
                 # dataset flushed, reset skipped sample count
                 if transform_dataset.start_input_idx is None:
                     skipped_samples_in_current_batch = 0

--- a/deeplake/util/transform.py
+++ b/deeplake/util/transform.py
@@ -26,6 +26,7 @@ from deeplake.util.remove_cache import (
 from deeplake.util.keys import get_tensor_meta_key
 from deeplake.util.version_control import auto_checkout, load_meta
 from deeplake.util.exceptions import (
+    AllSamplesSkippedError,
     InvalidInputDataError,
     InvalidOutputDatasetError,
     InvalidTransformDataset,
@@ -164,6 +165,7 @@ def _handle_transform_error(
     ignore_errors,
 ):
     start_input_idx = transform_dataset.start_input_idx
+    skipped_samples = 0
     for i in range(start_input_idx, end_input_idx + 1):
         sample = (
             data_slice[i : i + 1]
@@ -178,8 +180,10 @@ def _handle_transform_error(
             transform_dataset.flush()
         except Exception as e:
             if isinstance(e, SampleAppendError) and ignore_errors:
+                skipped_samples += 1
                 continue
             raise TransformError(offset + i, sample) from e
+    return skipped_samples
 
 
 def _transform_and_append_data_slice(
@@ -192,7 +196,10 @@ def _transform_and_append_data_slice(
     pg_callback,
     ignore_errors,
 ):
+    """Appends a data slice. Returns ``True`` if any samples were appended and ``False`` otherwise."""
     n = len(data_slice)
+    skipped_samples = 0
+    skipped_samples_in_current_batch = 0
 
     pipeline_checked = False
 
@@ -206,28 +213,41 @@ def _transform_and_append_data_slice(
 
             try:
                 out = transform_sample(sample, pipeline, tensors)
+
+                if not pipeline_checked:
+                    _check_pipeline(out, tensors, skip_ok)
+                    pipeline_checked = True
+                
+                write_sample_to_transform_dataset(out, transform_dataset)
+
             except SampleAppendError as e:
                 if ignore_errors:
-                    continue
-                raise TransformError(offset + i, sample) from e
+                    skipped_samples += 1
+                    skipped_samples_in_current_batch += 1
+                else:
+                    raise TransformError(offset + i, sample) from e
 
-            if not pipeline_checked:
-                _check_pipeline(out, tensors, skip_ok)
-                pipeline_checked = True
+            finally:
+                if i == n - 1:
+                    transform_dataset.flush()
+                else:
+                    transform_dataset.check_flush()
+            
+                # dataset flushed, reset skipped sample count
+                if transform_dataset.start_input_idx is None:
+                    skipped_samples_in_current_batch = 0
 
-            write_sample_to_transform_dataset(out, transform_dataset)
+                if pg_callback is not None:
+                    pg_callback(1)
 
-            if i == n - 1:
-                transform_dataset.flush()
-            else:
-                transform_dataset.check_flush()
-
-            if pg_callback is not None:
-                pg_callback(1)
+        # failure at chunk_engine
+        # retry one sample at a time
         except SampleAppendError:
-            # failure at chunk_engine
-            # retry one sample at a time
-            _handle_transform_error(
+            # reset skipped sample count to avoid double counting
+            skipped_samples -= skipped_samples_in_current_batch
+            skipped_samples_in_current_batch = 0
+
+            skipped_samples += _handle_transform_error(
                 data_slice,
                 offset,
                 transform_dataset,
@@ -237,6 +257,10 @@ def _transform_and_append_data_slice(
                 ignore_errors,
             )
             continue
+
+    if skipped_samples == n:
+        return False
+    return True
 
 
 def _retrieve_memory_objects(all_chunk_engines):
@@ -313,7 +337,7 @@ def store_data_slice_with_pbar(pg_callback, transform_input: Tuple) -> Dict:
             data_slice, offset, transform_dataset, pipeline.functions[0], pg_callback
         )
     else:
-        _transform_and_append_data_slice(
+        ret = _transform_and_append_data_slice(
             data_slice,
             offset,
             transform_dataset,
@@ -325,7 +349,9 @@ def store_data_slice_with_pbar(pg_callback, transform_input: Tuple) -> Dict:
         )
 
     # retrieve relevant objects from memory
-    return _retrieve_memory_objects(all_chunk_engines)
+    meta = _retrieve_memory_objects(all_chunk_engines)
+    meta["all_samples_skipped"] = not ret
+    return meta
 
 
 def create_worker_chunk_engines(
@@ -565,6 +591,8 @@ def sanitize_workers_scheduler(num_workers, scheduler):
 
 
 def process_transform_result(result: List[Dict]):
+    if all(res.get("all_samples_skipped") for res in result):
+        raise AllSamplesSkippedError
     if not result:
         return result
     final = defaultdict(list)


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
- AllSamplesSkippedError if all samples were skipped in a transform by `ignore_errors` param
- Bugfix for when a bad sample is at the end of transform, samples doesn't get flushed
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->