### PR TITLE
[AL-2277] Avoid producing corrupt datasets in transforms

### DIFF
--- a/deeplake/core/transform/test_transform.py
+++ b/deeplake/core/transform/test_transform.py
@@ -1550,6 +1550,7 @@ def test_pad_data_in_bug(local_ds):
 
     ds2.delete()
 
+
 def test_no_corruption(local_ds):
     @deeplake.compute
     def upload(stuff, ds):
@@ -1558,8 +1559,17 @@ def test_no_corruption(local_ds):
     with local_ds as ds:
         ds.create_tensor("images", htype="image", sample_compression="png")
         ds.create_tensor("labels", htype="class_label")
-    
-    samples = ([{"images": np.random.randint(0, 256, (10, 10, 3), dtype=np.uint8), "labels": 1} for _ in range(20)] + ["bad_sample"]) * 2
+
+    samples = (
+        [
+            {
+                "images": np.random.randint(0, 256, (10, 10, 3), dtype=np.uint8),
+                "labels": 1,
+            }
+            for _ in range(20)
+        ]
+        + ["bad_sample"]
+    ) * 2
 
     with pytest.raises(TransformError):
         upload().eval(samples, ds, num_workers=TRANSFORM_TEST_NUM_WORKERS)

--- a/deeplake/core/transform/transform.py
+++ b/deeplake/core/transform/transform.py
@@ -450,6 +450,10 @@ class Pipeline:
                 scheduler=scheduler,
                 verbose=progressbar,
             )
+        
+        for res in result["error"]:
+            if res is not None:
+                raise res
 
 
 def compose(functions: List[ComputeFunction]):  # noqa: DAR101, DAR102, DAR201, DAR401

--- a/deeplake/core/transform/transform.py
+++ b/deeplake/core/transform/transform.py
@@ -450,7 +450,7 @@ class Pipeline:
                 scheduler=scheduler,
                 verbose=progressbar,
             )
-        
+
         for res in result["error"]:
             if res is not None:
                 raise res

--- a/deeplake/core/transform/transform_dataset.py
+++ b/deeplake/core/transform/transform_dataset.py
@@ -1,4 +1,4 @@
-from deeplake.util.exceptions import SampleAppendError, TensorDoesNotExistError
+from deeplake.util.exceptions import SampleAppendError, SampleAppendingError
 from deeplake.core.transform.transform_tensor import TransformTensor
 from deeplake.core.linked_tiled_sample import LinkedTiledSample
 from deeplake.core.partial_sample import PartialSample
@@ -60,6 +60,9 @@ class TransformDataset:
             yield self[i]
 
     def append(self, sample, skip_ok=False, append_empty=False):
+        if not isinstance(sample, dict):
+            raise SampleAppendingError()
+
         if skip_ok:
             raise ValueError(
                 "`skip_ok` is not supported for `ds.append` in transforms. Use `skip_ok` parameter of the `eval` method instead."

--- a/deeplake/util/transform.py
+++ b/deeplake/util/transform.py
@@ -337,7 +337,11 @@ def store_data_slice_with_pbar(pg_callback, transform_input: Tuple) -> Dict:
     try:
         if extend_only:
             _extend_data_slice(
-                data_slice, offset, transform_dataset, pipeline.functions[0], pg_callback
+                data_slice,
+                offset,
+                transform_dataset,
+                pipeline.functions[0],
+                pg_callback,
             )
         else:
             ret = _transform_and_append_data_slice(

--- a/deeplake/util/transform.py
+++ b/deeplake/util/transform.py
@@ -333,26 +333,31 @@ def store_data_slice_with_pbar(pg_callback, transform_input: Tuple) -> Dict:
     )
 
     ret = True
-    if extend_only:
-        _extend_data_slice(
-            data_slice, offset, transform_dataset, pipeline.functions[0], pg_callback
-        )
-    else:
-        ret = _transform_and_append_data_slice(
-            data_slice,
-            offset,
-            transform_dataset,
-            pipeline,
-            rel_tensors,
-            skip_ok,
-            pg_callback,
-            ignore_errors,
-        )
-
-    # retrieve relevant objects from memory
-    meta = _retrieve_memory_objects(all_chunk_engines)
-    meta["all_samples_skipped"] = not ret
-    return meta
+    err = None
+    try:
+        if extend_only:
+            _extend_data_slice(
+                data_slice, offset, transform_dataset, pipeline.functions[0], pg_callback
+            )
+        else:
+            ret = _transform_and_append_data_slice(
+                data_slice,
+                offset,
+                transform_dataset,
+                pipeline,
+                rel_tensors,
+                skip_ok,
+                pg_callback,
+                ignore_errors,
+            )
+    except Exception as e:
+        err = e
+    finally:
+        # retrieve relevant objects from memory
+        meta = _retrieve_memory_objects(all_chunk_engines)
+        meta["all_samples_skipped"] = not ret
+        meta["error"] = err
+        return meta
 
 
 def create_worker_chunk_engines(
@@ -568,7 +573,7 @@ def get_lengths_generated(all_tensor_metas, tensors):
 
 
 def check_lengths(all_tensors_generated_length, skip_ok):
-    if not skip_ok:
+    if skip_ok:
         return
 
     first_length = None

--- a/deeplake/util/transform.py
+++ b/deeplake/util/transform.py
@@ -355,6 +355,7 @@ def store_data_slice_with_pbar(pg_callback, transform_input: Tuple) -> Dict:
                 ignore_errors,
             )
     except Exception as e:
+        transform_dataset.flush()
         err = e
     finally:
         # retrieve relevant objects from memory

--- a/deeplake/util/transform.py
+++ b/deeplake/util/transform.py
@@ -355,6 +355,7 @@ def store_data_slice_with_pbar(pg_callback, transform_input: Tuple) -> Dict:
                 ignore_errors,
             )
     except Exception as e:
+        print(e)
         transform_dataset.flush()
         err = e
     finally:


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
- Produce useable datasets in transforms even in case of errors.
- Ordering of samples will not be correct if multiple workers are used (therefore non-resumable) but this state will be better than an unusable dataset
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->