### PR TITLE
[AL-2278] append_empty option in transforms

### DIFF
--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -2812,9 +2812,6 @@ class Dataset:
         if not isinstance(sample, dict):
             raise SampleAppendingError()
 
-        if skip_ok and append_empty:
-            raise ValueError("Only one of `skip_ok` and `append_empty` can be True.")
-
         skipped_tensors = [k for k in tensors if k not in sample]
         if skipped_tensors and not skip_ok and not append_empty:
             raise KeyError(

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -2812,6 +2812,9 @@ class Dataset:
         if not isinstance(sample, dict):
             raise SampleAppendingError()
 
+        if skip_ok and append_empty:
+            raise ValueError("Only one of `skip_ok` and `append_empty` can be True.")
+
         skipped_tensors = [k for k in tensors if k not in sample]
         if skipped_tensors and not skip_ok and not append_empty:
             raise KeyError(

--- a/deeplake/core/transform/test_transform.py
+++ b/deeplake/core/transform/test_transform.py
@@ -1554,7 +1554,7 @@ def test_pad_data_in_bug(local_ds):
 
 def test_ds_append_empty(local_ds):
     @deeplake.compute
-    def upload(stuff, ds):
+    def upload(stuff, ds): 
         ds.append(stuff, append_empty=True)
 
     with local_ds as ds:

--- a/deeplake/core/transform/test_transform.py
+++ b/deeplake/core/transform/test_transform.py
@@ -13,6 +13,7 @@ from deeplake.util.remove_cache import remove_memory_cache
 from deeplake.util.check_installation import ray_installed
 from deeplake.util.exceptions import (
     AllSamplesSkippedError,
+    EmptyTensorError,
     InvalidOutputDatasetError,
     TransformError,
 )
@@ -1549,3 +1550,25 @@ def test_pad_data_in_bug(local_ds):
     np.testing.assert_array_equal(ds2.xyz.numpy(), ds.xyz.numpy())
 
     ds2.delete()
+
+
+def test_ds_append_empty(local_ds):
+    @deeplake.compute
+    def upload(stuff, ds):
+        ds.append(stuff, append_empty=True)
+    
+    with local_ds as ds:
+        ds.create_tensor("images", htype="image", sample_compression="png")
+        ds.create_tensor("label1", htype="class_label")
+        ds.create_tensor("label2", htype="class_label")
+
+    samples = [{"images": np.random.randint(0, 255, (10, 10, 3), dtype=np.uint8), "label1": 1} for _ in range(20)]
+
+    upload().eval(samples, ds, num_workers=TRANSFORM_TEST_NUM_WORKERS)
+
+    with pytest.raises(EmptyTensorError):
+        ds.label2.numpy()
+    
+    ds.label2.append(1)
+    
+    np.testing.assert_array_equal(ds.label2[:20].numpy(), np.array([]).reshape((20, 0)))

--- a/deeplake/core/transform/test_transform.py
+++ b/deeplake/core/transform/test_transform.py
@@ -1554,7 +1554,7 @@ def test_pad_data_in_bug(local_ds):
 
 def test_ds_append_empty(local_ds):
     @deeplake.compute
-    def upload(stuff, ds): 
+    def upload(stuff, ds):
         ds.append(stuff, append_empty=True)
 
     with local_ds as ds:

--- a/deeplake/core/transform/test_transform.py
+++ b/deeplake/core/transform/test_transform.py
@@ -1556,19 +1556,22 @@ def test_ds_append_empty(local_ds):
     @deeplake.compute
     def upload(stuff, ds):
         ds.append(stuff, append_empty=True)
-    
+
     with local_ds as ds:
         ds.create_tensor("images", htype="image", sample_compression="png")
         ds.create_tensor("label1", htype="class_label")
         ds.create_tensor("label2", htype="class_label")
 
-    samples = [{"images": np.random.randint(0, 255, (10, 10, 3), dtype=np.uint8), "label1": 1} for _ in range(20)]
+    samples = [
+        {"images": np.random.randint(0, 255, (10, 10, 3), dtype=np.uint8), "label1": 1}
+        for _ in range(20)
+    ]
 
     upload().eval(samples, ds, num_workers=TRANSFORM_TEST_NUM_WORKERS)
 
     with pytest.raises(EmptyTensorError):
         ds.label2.numpy()
-    
+
     ds.label2.append(1)
-    
+
     np.testing.assert_array_equal(ds.label2[:20].numpy(), np.array([]).reshape((20, 0)))

--- a/deeplake/core/transform/transform_dataset.py
+++ b/deeplake/core/transform/transform_dataset.py
@@ -72,10 +72,9 @@ class TransformDataset:
 
         for k in self.tensors:
             if k in sample:
-                v = sample[k]
+                self[k].append(sample[k])
             elif append_empty:
-                v = None
-            self[k].append(v)
+                self[k].append(None)
 
     def item_added(self, item):
         if isinstance(item, Sample):

--- a/deeplake/core/transform/transform_dataset.py
+++ b/deeplake/core/transform/transform_dataset.py
@@ -61,7 +61,9 @@ class TransformDataset:
 
     def append(self, sample, skip_ok=False, append_empty=False):
         if skip_ok:
-            raise ValueError("`skip_ok` is not supported for `ds.append` in transforms. Use `skip_ok` parameter of the `eval` method instead.")
+            raise ValueError(
+                "`skip_ok` is not supported for `ds.append` in transforms. Use `skip_ok` parameter of the `eval` method instead."
+            )
 
         if len(set(map(len, (self[k] for k in sample)))) != 1:
             raise ValueError(

--- a/deeplake/core/transform/transform_tensor.py
+++ b/deeplake/core/transform/transform_tensor.py
@@ -112,10 +112,9 @@ class TransformTensor:
 
     def append(self, item):
         """Adds an item to the tensor."""
+        if self.is_group:
+            raise TensorDoesNotExistError(self.name)
         try:
-            if self.is_group:
-                raise TensorDoesNotExistError(self.name)
-
             # optimization applicable only if extending
             self.non_numpy_only()
 

--- a/deeplake/util/class_label.py
+++ b/deeplake/util/class_label.py
@@ -2,6 +2,7 @@ from collections import OrderedDict, defaultdict
 from typing import List
 
 from deeplake.util.hash import hash_str_to_int32
+from deeplake.util.exceptions import EmptyTensorError
 from deeplake.client.log import logger
 import numpy as np
 import deeplake
@@ -84,8 +85,11 @@ def sync_labels(
         label_tensor: str,
         hash_idx_map,
     ):
-        hashes = hash_tensor_sample.numpy().tolist()
-        idxs = convert_hash_to_idx(hashes, hash_idx_map)
+        try:
+            hashes = hash_tensor_sample.numpy().tolist()
+            idxs = convert_hash_to_idx(hashes, hash_idx_map)
+        except EmptyTensorError:
+            idxs = None
         samples_out[label_tensor].append(idxs)
 
     for tensor, temp_tensor in label_temp_tensors.items():


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
- Use `ds.append(..., append_empty=True)` to append empty samples to unspecified tensors in transforms
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->