### PR TITLE
[AL-2280] Fix numpy slowdown with iteration and groups

### DIFF
--- a/deeplake/api/tests/test_api.py
+++ b/deeplake/api/tests/test_api.py
@@ -2457,3 +2457,15 @@ def test_sequence_numpy_bug(memory_ds):
             ds.abc.numpy()
 
         assert ds.abc.numpy(aslist=True) == [[1, 2], [1, 2, 3], [1, 2, 3, 4]]
+
+def test_iterate_with_groups(memory_ds):
+    with memory_ds as ds:
+        ds.create_tensor("x/y/z")
+    
+    ds["x/y/z"].extend(list(range(100)))
+
+    for i, sample in enumerate(ds):
+        assert sample["x/y"].z.is_iteration == True
+    
+    for i, sample in enumerate(ds):
+        assert sample["x/y/z"].is_iteration == True

--- a/deeplake/api/tests/test_api.py
+++ b/deeplake/api/tests/test_api.py
@@ -2458,14 +2458,15 @@ def test_sequence_numpy_bug(memory_ds):
 
         assert ds.abc.numpy(aslist=True) == [[1, 2], [1, 2, 3], [1, 2, 3, 4]]
 
+
 def test_iterate_with_groups(memory_ds):
     with memory_ds as ds:
         ds.create_tensor("x/y/z")
-    
+
     ds["x/y/z"].extend(list(range(100)))
 
     for i, sample in enumerate(ds):
         assert sample["x/y"].z.is_iteration == True
-    
+
     for i, sample in enumerate(ds):
         assert sample["x/y/z"].is_iteration == True

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -489,6 +489,7 @@ class Dataset:
                     verbose=False,
                     version_state=self.version_state,
                     path=self.path,
+                    is_iteration=is_iteration,
                     link_creds=self.link_creds,
                     pad_tensors=self._pad_tensors,
                     enabled_tensors=self.enabled_tensors,
@@ -1290,8 +1291,10 @@ class Dataset:
     def __iter__(self):
         dataset_read(self)
         for i in range(len(self)):
+            is_iter = not isinstance(self.index.values[0], list)
+            print("is_iter:", is_iter)
             yield self.__getitem__(
-                i, is_iteration=not isinstance(self.index.values[0], list)
+                i, is_iteration=is_iter
             )
 
     def _load_version_info(self, address=None):

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -1291,8 +1291,9 @@ class Dataset:
     def __iter__(self):
         dataset_read(self)
         for i in range(len(self)):
-            is_iter = not isinstance(self.index.values[0], list)
-            yield self.__getitem__(i, is_iteration=is_iter)
+            yield self.__getitem__(
+                i, is_iteration=not isinstance(self.index.values[0], list)
+            )
 
     def _load_version_info(self, address=None):
         """Loads data from version_control_file otherwise assume it doesn't exist and load all empty"""

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -1292,7 +1292,6 @@ class Dataset:
         dataset_read(self)
         for i in range(len(self)):
             is_iter = not isinstance(self.index.values[0], list)
-            print("is_iter:", is_iter)
             yield self.__getitem__(
                 i, is_iteration=is_iter
             )

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -1292,9 +1292,7 @@ class Dataset:
         dataset_read(self)
         for i in range(len(self)):
             is_iter = not isinstance(self.index.values[0], list)
-            yield self.__getitem__(
-                i, is_iteration=is_iter
-            )
+            yield self.__getitem__(i, is_iteration=is_iter)
 
     def _load_version_info(self, address=None):
         """Loads data from version_control_file otherwise assume it doesn't exist and load all empty"""


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
- Pass iteration flag to groups
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->