### PR TITLE
Added ds_name into deeplake_cloud_dataset.py

### DIFF
--- a/deeplake/api/dataset.py
+++ b/deeplake/api/dataset.py
@@ -26,6 +26,7 @@ from deeplake.util.path import (
     convert_pathlib_to_string_if_needed,
     verify_dataset_name,
     process_dataset_path,
+    get_path_type,
 )
 from deeplake.hooks import (
     dataset_created,
@@ -191,6 +192,9 @@ class dataset:
 
         path, address = process_dataset_path(path)
         verify_dataset_name(path)
+
+        if org_id is not None and get_path_type(path) != "local":
+            raise ValueError("org_id parameter can only be used with local datasets")
 
         if creds is None:
             creds = {}
@@ -377,6 +381,10 @@ class dataset:
             Setting ``overwrite`` to ``True`` will delete all of your data if it exists! Be very careful when setting this parameter.
         """
         path, address = process_dataset_path(path)
+
+        if org_id is not None and get_path_type(path) != "local":
+            raise ValueError("org_id parameter can only be used with local datasets")
+        
         db_engine = (runtime or {}).get("db_engine", False)
 
         if address:
@@ -537,6 +545,9 @@ class dataset:
 
         if creds is None:
             creds = {}
+        
+        if org_id is not None and get_path_type(path) != "local":
+            raise ValueError("org_id parameter can only be used with local datasets")
 
         try:
             storage, cache_chain = get_storage_and_cache_chain(
@@ -836,6 +847,10 @@ class dataset:
             path = dest.path
         else:
             path = dest
+
+        if org_id is not None and get_path_type(path) != "local":
+            raise ValueError("org_id parameter can only be used with local datasets")
+        
         feature_report_path(
             path,
             "like",

--- a/deeplake/api/tests/test_api.py
+++ b/deeplake/api/tests/test_api.py
@@ -2602,3 +2602,16 @@ def test_shape_squeeze(memory_ds):
         ds.abc.extend(np.ones((5, 10, 12, 20)))
 
     assert ds.abc[5:, :, 9].shape == (5, 10, 20)
+
+def test_non_local_org_id():
+    with pytest.raises(ValueError):
+        ds = deeplake.dataset("hub://test/test_dataset", org_id="test")
+    
+    with pytest.raises(ValueError):
+        ds = deeplake.empty("hub://test/test_dataset", org_id="test")
+    
+    with pytest.raises(ValueError):
+        ds = deeplake.load("hub://test/test_dataset", org_id="test")
+    
+    with pytest.raises(ValueError):
+        ds = deeplake.like("hub://test/test_dataset", "test/test_ds", org_id="test")

--- a/deeplake/core/dataset/deeplake_cloud_dataset.py
+++ b/deeplake/core/dataset/deeplake_cloud_dataset.py
@@ -59,7 +59,7 @@ class DeepLakeCloudDataset(Dataset):
 
     def _set_org_and_name(self):
         if self.is_actually_cloud:
-            if self.org_id is not None:
+            if self.org_id is not None and self.ds_name is not None:
                 return
             _, org_id, ds_name, subdir = process_hub_path(self.path)
             if subdir:


### PR DESCRIPTION
added missing `ds_name` field

## 🚀 🚀 Pull Request

There is a specific case in which I `deeplake.empty` is called and a cloud dataset path is passed. In that case a function called [`_is_sub_ds`](https://github.com/activeloopai/deeplake/blob/2bfa3a2a0617e63baf6343dbd61148c926dc0561/deeplake/core/dataset/deeplake_cloud_dataset.py#L76) is used to check if we have a sub directory dataset, since `ds_name` was not set the code was failing. 

To reproduce


```python

from deeplake.constants import MB
import numpy as np 

import deeplake

dataset_path = f"hub://<YOUR_ORG_ID>/<YOUR_DS_NAME>"


ds = deeplake.empty(
                path=dataset_path,
                runtime={"db_engine": True},
                token=<TOKE>,
                overwrite=True,
                org_id=<YOUR_ORG_ID>,
            )
```

Resulting in the follow error

```
Traceback (most recent call last):
  File "/home/zuppif/Documents/Work/ActiveLoop/see-and-say/playground.py", line 18, in <module>
    ds = deeplake.empty(
  File "/home/zuppif/miniconda3/envs/imagebind/lib/python3.8/site-packages/deeplake/api/dataset.py", line 427, in empty
    ret = dataset._load(dataset_kwargs)
  File "/home/zuppif/miniconda3/envs/imagebind/lib/python3.8/site-packages/deeplake/api/dataset.py", line 661, in _load
    ret = dataset_factory(**dataset_kwargs)
  File "/home/zuppif/miniconda3/envs/imagebind/lib/python3.8/site-packages/deeplake/core/dataset/__init__.py", line 23, in dataset_factory
    ds = clz(path=path, *args, **kwargs)
  File "/home/zuppif/miniconda3/envs/imagebind/lib/python3.8/site-packages/deeplake/core/dataset/dataset.py", line 241, in __init__
    self._set_derived_attributes(address=address)
  File "/home/zuppif/miniconda3/envs/imagebind/lib/python3.8/site-packages/deeplake/core/dataset/dataset.py", line 2226, in _set_derived_attributes
    self._populate_meta(verbose)  # TODO: use the same scheme as `load_info`
  File "/home/zuppif/miniconda3/envs/imagebind/lib/python3.8/site-packages/deeplake/core/dataset/dataset.py", line 1767, in _populate_meta
    self._register_dataset()
  File "/home/zuppif/miniconda3/envs/imagebind/lib/python3.8/site-packages/deeplake/core/dataset/deeplake_cloud_dataset.py", line 82, in _register_dataset
    if self._is_sub_ds():
  File "/home/zuppif/miniconda3/envs/imagebind/lib/python3.8/site-packages/deeplake/core/dataset/deeplake_cloud_dataset.py", line 77, in _is_sub_ds
    return "/" in self.ds_name
TypeError: argument of type 'NoneType' is not iterable
```

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

Added `ds_name` from `ds.path`