### PR TITLE
[AL-2302] Fix issue with SPINNER_ENABLED const

### DIFF
--- a/deeplake/util/spinner.py
+++ b/deeplake/util/spinner.py
@@ -132,10 +132,7 @@ class Spinner(threading.Thread):
 def spinner(func):
     @wraps(func)
     def inner(*args, **kwargs):
-        sp = True
-        if "spinner" in kwargs:
-            sp = kwargs.pop("spinner")
-        if sp and kwargs.get("verbose") in (None, True):
+        if kwargs.pop("spinner", True) and kwargs.get("verbose") in (None, True):
             spinner = Spinner()
 
             with run_spinner(spinner):

--- a/deeplake/util/spinner.py
+++ b/deeplake/util/spinner.py
@@ -132,7 +132,10 @@ class Spinner(threading.Thread):
 def spinner(func):
     @wraps(func)
     def inner(*args, **kwargs):
-        if kwargs.get("verbose") in (None, True):
+        sp = True
+        if "spinner" in kwargs:
+            sp = kwargs.pop("spinner")
+        if sp and kwargs.get("verbose") in (None, True):
             spinner = Spinner()
 
             with run_spinner(spinner):

--- a/deeplake/util/spinner.py
+++ b/deeplake/util/spinner.py
@@ -1,9 +1,9 @@
-from deeplake.constants import SPINNER_START_DELAY, SPINNER_ENABLED
 from deeplake.client.log import configure_logger
 from logging import StreamHandler
 from itertools import cycle
 from functools import wraps
 
+import deeplake
 import contextlib
 import threading
 import logging
@@ -32,7 +32,7 @@ class DummyFile:
 def run_spinner(spinner):
     global ACTIVE_SPINNER
     try:
-        if not isinstance(sys.stderr, DummyFile) and SPINNER_ENABLED:
+        if not isinstance(sys.stderr, DummyFile) and deeplake.constants.SPINNER_ENABLED:
             spinner.start()
             spinner_started = True
             save_stdout = sys.stdout
@@ -71,7 +71,7 @@ class Spinner(threading.Thread):
         self.file = sys.stderr
 
     def run(self):
-        time.sleep(SPINNER_START_DELAY)
+        time.sleep(deeplake.constants.SPINNER_START_DELAY)
         frames = cycle("/-\\|")
         if not self._hide_event.is_set():
             self._hide_cursor()


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

Setting `deeplake.constants.SPINNER_ENABLED = False` disables spinner.

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->