### PR TITLE
Vectorstore ids bakwards compatibility (not_none_tensors fix)

### DIFF
--- a/deeplake/core/vectorstore/test_deeplake_vectorstore.py
+++ b/deeplake/core/vectorstore/test_deeplake_vectorstore.py
@@ -44,6 +44,40 @@ def embedding_fn4(text, embedding_dim=EMBEDDING_DIM):
     return np.zeros((1, EMBEDDING_DIM))  # pragma: no cover
 
 
+def test_id_backward_compatibility(local_path):
+    num_of_items = 10
+    embedding_dim = 100
+
+    ids = [f"{i}" for i in range(num_of_items)]
+    embedding = [np.zeros(embedding_dim) for i in range(num_of_items)]
+    text = ["aadfv" for i in range(num_of_items)]
+    metadata = [{"key": i} for i in range(num_of_items)]
+
+    ds = deeplake.empty(local_path, overwrite=True)
+    ds.create_tensor("ids", htype="text")
+    ds.create_tensor("embedding", htype="embedding")
+    ds.create_tensor("text", htype="text")
+    ds.create_tensor("metadata", htype="json")
+
+    ds.extend(
+        {
+            "ids": ids,
+            "embedding": embedding,
+            "text": text,
+            "metadata": metadata,
+        }
+    )
+
+    vectorstore = VectorStore(path=local_path)
+    vectorstore.add(
+        text=text,
+        embedding=embedding,
+        metadata=metadata,
+    )
+
+    assert len(vectorstore) == 20
+
+
 def test_custom_tensors(local_path):
     # initialize vector store object:
     vector_store = DeepLakeVectorStore(

--- a/deeplake/core/vectorstore/vector_search/dataset/dataset.py
+++ b/deeplake/core/vectorstore/vector_search/dataset/dataset.py
@@ -288,9 +288,15 @@ def get_not_none_tensors(tensors, embedding_data):
 
 
 def populate_id_tensor_if_needed(ids_tensor, tensors, not_non_tensors, num_items):
-    if ids_tensor not in not_non_tensors:
+    if "id" not in not_non_tensors and "ids" not in not_non_tensors:
         id = [str(uuid.uuid1()) for _ in range(num_items)]
         tensors[ids_tensor] = id
+    else:
+        for tensor in not_non_tensors:
+            if tensor in ("id", "ids"):
+                break
+
+        tensors[ids_tensor] = not_non_tensors[tensor]
     return tensors
 
 

--- a/deeplake/core/vectorstore/vector_search/dataset/dataset.py
+++ b/deeplake/core/vectorstore/vector_search/dataset/dataset.py
@@ -237,10 +237,10 @@ def preprocess_tensors(
 ):
     # generate id list equal to the length of the tensors
     # dont use None tensors to get length of tensor
-    not_non_tensors, num_items = get_not_none_tensors(tensors, embedding_data)
+    not_none_tensors, num_items = get_not_none_tensors(tensors, embedding_data)
     ids_tensor = get_id_tensor(dataset)
     tensors = populate_id_tensor_if_needed(
-        ids_tensor, tensors, not_non_tensors, num_items
+        ids_tensor, tensors, not_none_tensors, num_items
     )
 
     processed_tensors = {ids_tensor: tensors[ids_tensor]}
@@ -276,27 +276,27 @@ def convert_tensor_data_to_list(tensor_data, tensors, ids_tensor):
 
 
 def get_not_none_tensors(tensors, embedding_data):
-    not_non_tensors = {k: v for k, v in tensors.items() if v is not None}
+    not_none_tensors = {k: v for k, v in tensors.items() if v is not None}
     try:
-        num_items = len(next(iter(not_non_tensors.values())))
+        num_items = len(next(iter(not_none_tensors.values())))
     except StopIteration:
         if embedding_data:
             num_items = len(embedding_data[0])
         else:
             num_items = 0
-    return not_non_tensors, num_items
+    return not_none_tensors, num_items
 
 
-def populate_id_tensor_if_needed(ids_tensor, tensors, not_non_tensors, num_items):
-    if "id" not in not_non_tensors and "ids" not in not_non_tensors:
+def populate_id_tensor_if_needed(ids_tensor, tensors, not_none_tensors, num_items):
+    if "id" not in not_none_tensors and "ids" not in not_none_tensors:
         id = [str(uuid.uuid1()) for _ in range(num_items)]
         tensors[ids_tensor] = id
     else:
-        for tensor in not_non_tensors:
+        for tensor in not_none_tensors:
             if tensor in ("id", "ids"):
                 break
 
-        tensors[ids_tensor] = not_non_tensors[tensor]
+        tensors[ids_tensor] = not_none_tensors[tensor]
     return tensors
 
 

--- a/deeplake/core/vectorstore/vector_search/dataset/dataset.py
+++ b/deeplake/core/vectorstore/vector_search/dataset/dataset.py
@@ -237,31 +237,17 @@ def preprocess_tensors(
 ):
     # generate id list equal to the length of the tensors
     # dont use None tensors to get length of tensor
-    _tensors = {k: v for k, v in tensors.items() if v is not None}
-    try:
-        num_items = len(next(iter(_tensors.values())))
-    except StopIteration:
-        if embedding_data:
-            num_items = len(embedding_data[0])
-        else:
-            num_items = 0
-    ids_tensor = "ids" if "ids" in _tensors else "id"
-    if ids_tensor not in _tensors or ids_tensor is None:
-        id = [str(uuid.uuid1()) for _ in range(num_items)]
-        tensors[ids_tensor] = id
+    not_non_tensors, num_items = get_not_none_tensors(tensors, embedding_data)
+    ids_tensor = get_id_tensor(dataset)
+    tensors = populate_id_tensor_if_needed(
+        ids_tensor, tensors, not_non_tensors, num_items
+    )
 
     processed_tensors = {ids_tensor: tensors[ids_tensor]}
 
     for tensor_name, tensor_data in tensors.items():
-        if tensor_data is None:
-            tensor_data = [None] * len(tensors[ids_tensor])
-        elif not isinstance(tensor_data, list):
-            tensor_data = list(tensor_data)
-        if dataset and dataset[tensor_name].htype == "image":
-            tensor_data = [
-                deeplake.read(data) if isinstance(data, str) else data
-                for data in tensor_data
-            ]
+        tensor_data = convert_tensor_data_to_list(tensor_data, tensors, ids_tensor)
+        tensor_data = read_tensor_data_if_needed(tensor_data, dataset, tensor_name)
         processed_tensors[tensor_name] = tensor_data
 
     if embedding_data:
@@ -269,6 +255,47 @@ def preprocess_tensors(
             processed_tensors[k] = v
 
     return processed_tensors, tensors[ids_tensor]
+
+
+def read_tensor_data_if_needed(tensor_data, dataset, tensor_name):
+    # generalize this method for other htypes that need reading.
+    if dataset and tensor_name != "id" and dataset[tensor_name].htype == "image":
+        tensor_data = [
+            deeplake.read(data) if isinstance(data, str) else data
+            for data in tensor_data
+        ]
+    return tensor_data
+
+
+def convert_tensor_data_to_list(tensor_data, tensors, ids_tensor):
+    if tensor_data is None:
+        tensor_data = [None] * len(tensors[ids_tensor])
+    elif not isinstance(tensor_data, list):
+        tensor_data = list(tensor_data)
+    return tensor_data
+
+
+def get_not_none_tensors(tensors, embedding_data):
+    not_non_tensors = {k: v for k, v in tensors.items() if v is not None}
+    try:
+        num_items = len(next(iter(not_non_tensors.values())))
+    except StopIteration:
+        if embedding_data:
+            num_items = len(embedding_data[0])
+        else:
+            num_items = 0
+    return not_non_tensors, num_items
+
+
+def populate_id_tensor_if_needed(ids_tensor, tensors, not_non_tensors, num_items):
+    if ids_tensor not in not_non_tensors:
+        id = [str(uuid.uuid1()) for _ in range(num_items)]
+        tensors[ids_tensor] = id
+    return tensors
+
+
+def get_id_tensor(dataset):
+    return "ids" if "ids" in dataset.tensors else "id"
 
 
 def create_elements(

--- a/deeplake/core/vectorstore/vector_search/dataset/test_dataset.py
+++ b/deeplake/core/vectorstore/vector_search/dataset/test_dataset.py
@@ -246,13 +246,20 @@ def test_embeding_data():
     assert embedding.shape == (1, 1538)
 
 
-def test_preprocess_tensors():
+def test_preprocess_tensors(local_path):
+    dataset = deeplake.empty(local_path, overwrite=True)
+
+    dataset.create_tensor("ids", htype="text")
+    dataset.create_tensor("metadata", htype="json")
+    dataset.create_tensor("embedding", htype="embedding")
+    dataset.create_tensor("text", htype="text")
+
     texts = ["a", "b", "c", "d"]
     processed_tensors, ids = dataset_utils.preprocess_tensors(
-        text=texts,
+        text=texts, dataset=dataset
     )
 
-    assert len(processed_tensors["id"]) == 4
+    assert len(processed_tensors["ids"]) == 4
     assert processed_tensors["text"] == texts
 
     texts = ("a", "b", "c", "d")
@@ -264,14 +271,22 @@ def test_preprocess_tensors():
         text=texts,
         metadata=metadatas,
         embedding=embeddings,
+        dataset=dataset,
     )
-    assert np.array_equal(processed_tensors["id"], ids)
+    assert np.array_equal(processed_tensors["ids"], ids)
     assert processed_tensors["text"] == list(texts)
     assert processed_tensors["metadata"] == metadatas
     assert processed_tensors["embedding"] == embeddings
 
 
-def test_create_elements():
+def test_create_elements(local_path):
+    dataset = deeplake.empty(local_path, overwrite=True)
+
+    dataset.create_tensor("ids", htype="text")
+    dataset.create_tensor("metadata", htype="json")
+    dataset.create_tensor("embedding", htype="embedding")
+    dataset.create_tensor("text", htype="text")
+
     ids = np.array([1, 2, 3, 4])
     texts = ["a", "b", "c", "d"]
     metadatas = [{"a": 1}, {"b": 2}, {"c": 3}, {"d": 4}]
@@ -310,7 +325,7 @@ def test_create_elements():
         )
 
     processed_tensors, ids = dataset_utils.preprocess_tensors(
-        id=ids, text=texts, embedding=embeddings, metadata=metadatas
+        dataset=dataset, id=ids, text=texts, embedding=embeddings, metadata=metadatas
     )
     elements = dataset_utils.create_elements(processed_tensors)
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

fixed not_none_tensors typo