### PR TITLE
[AL-2322] Improved dataset directory validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ wandb/
 *Python-3.7*
 *mem:/*
 hub_pytest/
+deeplake/test-dataset
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -199,6 +199,7 @@ logs/
 .vscode/
 .creds/
 .idea/
+*.iml
 .nvimrc
 .vimrc
 waymo/
@@ -213,5 +214,8 @@ benchmarks/hub_data
 benchmarks/torch_data
 .benchmarks/
 
+deeplake/test-dataset
+
 # API docs
 api_docs/
+

--- a/.gitignore
+++ b/.gitignore
@@ -215,8 +215,5 @@ benchmarks/hub_data
 benchmarks/torch_data
 .benchmarks/
 
-deeplake/test-dataset
-
 # API docs
 api_docs/
-

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -107,7 +107,6 @@ from deeplake.util.exceptions import (
 )
 from deeplake.util.keys import (
     dataset_exists,
-    dataset_validate,
     get_dataset_info_key,
     get_dataset_meta_key,
     tensor_exists,
@@ -1761,7 +1760,6 @@ class Dataset:
     def _populate_meta(self, verbose=True):
         """Populates the meta information for the dataset."""
         if dataset_exists(self.storage):
-            dataset_validate(self.storage)
             load_meta(self)
 
         elif not self.storage.empty():

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -107,6 +107,7 @@ from deeplake.util.exceptions import (
 )
 from deeplake.util.keys import (
     dataset_exists,
+    dataset_validate,
     get_dataset_info_key,
     get_dataset_meta_key,
     tensor_exists,
@@ -1760,6 +1761,7 @@ class Dataset:
     def _populate_meta(self, verbose=True):
         """Populates the meta information for the dataset."""
         if dataset_exists(self.storage):
+            dataset_validate(self.storage)
             load_meta(self)
 
         elif not self.storage.empty():

--- a/deeplake/util/keys.py
+++ b/deeplake/util/keys.py
@@ -29,7 +29,6 @@ from deeplake.util.exceptions import (
     S3GetError,
     S3GetAccessError,
     AuthorizationException,
-    DatasetCorruptError,
 )
 
 

--- a/deeplake/util/keys.py
+++ b/deeplake/util/keys.py
@@ -196,22 +196,8 @@ def dataset_exists(storage) -> bool:
         )
     except S3GetAccessError as err:
         raise AuthorizationException("The dataset storage cannot be accessed") from err
-    except S3GetError:
+    except (KeyError, S3GetError) as err:
         return False
-
-
-def dataset_validate(storage) -> None:
-    """
-    Checks the structure of the dataset and throws a descriptive DatasetCorruptError for any problems.
-    """
-    try:
-        for file in [get_dataset_meta_key(FIRST_COMMIT_ID), get_version_control_info_key()]:
-            if file not in storage:
-                raise DatasetCorruptError(f"Invalid dataset: missing file {file}")
-    except S3GetAccessError as err:
-        raise AuthorizationException("The dataset storage cannot be accessed") from err
-    except S3GetError:
-        raise DatasetCorruptError("Error reading from S3")
 
 
 def tensor_exists(key: str, storage, commit_id: str) -> bool:

--- a/deeplake/util/keys.py
+++ b/deeplake/util/keys.py
@@ -186,7 +186,6 @@ def dataset_exists(storage) -> bool:
     """
     Returns true if a dataset exists at the given location.
     NOTE: This does not verify if it is a VALID dataset, only that it exists and is likely a deeplake directory.
-    To verify the content, use :func:`dataset_valid`
     """
     try:
         return (

--- a/deeplake/util/keys.py
+++ b/deeplake/util/keys.py
@@ -190,8 +190,8 @@ def dataset_exists(storage) -> bool:
     """
     try:
         return (
-                get_dataset_meta_key(FIRST_COMMIT_ID) in storage
-                or get_version_control_info_key() in storage
+            get_dataset_meta_key(FIRST_COMMIT_ID) in storage
+            or get_version_control_info_key() in storage
         )
     except S3GetAccessError as err:
         raise AuthorizationException("The dataset storage cannot be accessed") from err

--- a/deeplake/util/tests/test_keys.py
+++ b/deeplake/util/tests/test_keys.py
@@ -7,15 +7,15 @@ def test_dataset_exists():
     assert dataset_exists(ds.storage)
 
     # Single files missing is fine
-    del ds.storage['version_control_info.json']
+    del ds.storage["version_control_info.json"]
     assert dataset_exists(ds.storage)
 
     ds = deeplake.dataset("mem://x")
-    del ds.storage['dataset_meta.json']
+    del ds.storage["dataset_meta.json"]
     assert dataset_exists(ds.storage)
 
     # Enough files are missing and it's no longer valid
     ds = deeplake.dataset("mem://x")
-    del ds.storage['dataset_meta.json']
-    del ds.storage['version_control_info.json']
+    del ds.storage["dataset_meta.json"]
+    del ds.storage["version_control_info.json"]
     assert not dataset_exists(ds.storage)

--- a/deeplake/util/tests/test_keys.py
+++ b/deeplake/util/tests/test_keys.py
@@ -1,0 +1,21 @@
+import deeplake
+from deeplake.util.keys import dataset_exists
+
+
+def test_dataset_exists():
+    ds = deeplake.dataset("mem://x")
+    assert dataset_exists(ds.storage)
+
+    # Single files missing is fine
+    del ds.storage['version_control_info.json']
+    assert dataset_exists(ds.storage)
+
+    ds = deeplake.dataset("mem://x")
+    del ds.storage['dataset_meta.json']
+    assert dataset_exists(ds.storage)
+
+    # Enough files are missing and it's no longer valid
+    ds = deeplake.dataset("mem://x")
+    del ds.storage['dataset_meta.json']
+    del ds.storage['version_control_info.json']
+    assert not dataset_exists(ds.storage)


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [X]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [X]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [X]  I have performed a self-review of my own code and resolved any problems
- [X]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

Currently, if a single file is missing in a dataset folder (`dataset_meta.json`), Deep Lake thinks it’s not a deeplake dataset leading to a confusing error of `….."A Deep Lake dataset does not exist at the given path….."`. 

This make this check more sophisticated, making "the is this a dataset directory" check look for a variety of files while also adding a "validation" function for times when any of them missing will be a problem. 