### PR TITLE
Fixed dataset_diff.py tobytes for names from larger/smaller charsets

### DIFF
--- a/deeplake/core/version_control/dataset_diff.py
+++ b/deeplake/core/version_control/dataset_diff.py
@@ -36,10 +36,13 @@ class DatasetDiff(DeepLakeMemoryObject):
                         [
                             len(old_name).to_bytes(8, "big"),
                             len(new_name).to_bytes(8, "big"),
-                            (old_name + new_name).encode("utf-8"),
+                            (old_name + new_name),
                         ]
                     )
-                    for old_name, new_name in self.renamed.items()
+                    for old_name, new_name in map(
+                        lambda n: (n[0].encode("utf-8"), n[1].encode("utf-8")),
+                        self.renamed.items(),
+                    )
                 ),
                 len(self.deleted).to_bytes(8, "big"),
                 *(

--- a/deeplake/core/version_control/test/test_dataset_diff.py
+++ b/deeplake/core/version_control/test/test_dataset_diff.py
@@ -1,0 +1,30 @@
+from deeplake.core.version_control.dataset_diff import DatasetDiff
+
+
+def test_tobytes():
+    diff = DatasetDiff()
+    diff.tensor_renamed("old1", "newer1")
+    diff.tensor_renamed("old2", "\u604f\u7D59")
+    diff.tensor_deleted("deleted1")
+    diff.tensor_deleted("deleted2")
+    diff.tensor_deleted("deleted3")
+
+    assert diff.tobytes() == b"".join(
+        [
+            False.to_bytes(1, "big"),
+            int(2).to_bytes(8, "big"),
+            len("old1".encode("utf-8")).to_bytes(8, "big"),
+            len("newer1".encode("utf-8")).to_bytes(8, "big"),
+            "old1newer1".encode("utf-8"),
+            len("old2".encode("utf-8")).to_bytes(8, "big"),
+            len("\u604f\u7D59".encode("utf-8")).to_bytes(8, "big"),
+            "old2\u604f\u7D59".encode("utf-8"),
+            int(3).to_bytes(8, "big"),
+            len("deleted1".encode("utf-8")).to_bytes(8, "big"),
+            "deleted1".encode("utf-8"),
+            len("deleted2".encode("utf-8")).to_bytes(8, "big"),
+            "deleted2".encode("utf-8"),
+            len("deleted3".encode("utf-8")).to_bytes(8, "big"),
+            "deleted3".encode("utf-8"),
+        ]
+    )


### PR DESCRIPTION
## 🚀 🚀 Pull Request

Better enforce utf-8 encoding key names to avoid bugs from non-utf8 base names 

Fixes #2445
