### PR TITLE
Add CSRFProtect to flask

### DIFF
--- a/deeplake/requirements/common.txt
+++ b/deeplake/requirements/common.txt
@@ -15,6 +15,7 @@ av>=8.1.0; python_version >= '3.7' or sys_platform != 'win32'
 pydicom
 IPython
 flask
+Flask-WTF
 pyjwt
 laspy
 nibabel

--- a/deeplake/visualizer/video_streaming.py
+++ b/deeplake/visualizer/video_streaming.py
@@ -2,6 +2,8 @@
 
 from typing import Optional, Callable, Tuple
 from flask import Flask, request, Response
+from flask_wtf import CSRFProtect
+
 from deeplake.core.meta.encode.chunk_id import ChunkIdEncoder
 from deeplake.core.storage import StorageProvider
 from deeplake.core.meta.encode.byte_positions import BytePositionsEncoder
@@ -175,6 +177,8 @@ def _stop_server():
 
 
 _APP = Flask("video_stream")
+csrf = CSRFProtect()
+csrf.init_app(_APP)
 
 
 @_APP.after_request

--- a/deeplake/visualizer/visualizer.py
+++ b/deeplake/visualizer/visualizer.py
@@ -2,6 +2,8 @@ import json
 from typing import Dict, Optional, Union
 import uuid
 from flask import Flask, request, Response
+from flask_wtf import CSRFProtect
+
 from deeplake.core.link_creds import LinkCreds  # type: ignore
 from deeplake.core.storage import StorageProvider
 from deeplake.core.storage.s3 import S3Provider
@@ -20,6 +22,8 @@ from IPython.display import IFrame, display  # type: ignore
 
 _SERVER_THREAD: Optional[threading.Thread] = None
 _APP = Flask("dataset_visualizer")
+csrf = CSRFProtect()
+csrf.init_app(_APP)
 
 log = logging.getLogger("werkzeug")
 log.setLevel(logging.ERROR)


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

By default, Flask does not protect form a cross-site request forgery attack. This PR adds the CSRFProtect module as suggested by https://sonarcloud.io/organizations/activeloopai/rules?open=python%3AS4502&rule_key=python%3AS4502

### Things to be aware of

Is our usage of Flask worth adding this in for? We could just mark it as not a problem in sonar. At the same time, I don't think it adds much overhead, so seems fine to add to be safe?

### Things to worry about

Will adding this break existing ways we use the flask server?
