### PR TITLE
Fixed vector search with tensor_db exec_option without indra installed

### DIFF
--- a/deeplake/core/vectorstore/vector_search/indra/search_algorithm.py
+++ b/deeplake/core/vectorstore/vector_search/indra/search_algorithm.py
@@ -38,7 +38,10 @@ def search(
     Returns:
         Union[Dict, DeepLakeDataset]: Dictionary where keys are tensor names and values are the results of the search, or a Deep Lake dataset view.
     """
-    from indra import api  # type: ignore
+    try:
+        from indra import api  # type: ignore
+    except ImportError:
+        pass
 
     if tql_string:
         tql_query = tql_string

--- a/deeplake/core/vectorstore/vector_search/indra/search_algorithm.py
+++ b/deeplake/core/vectorstore/vector_search/indra/search_algorithm.py
@@ -4,6 +4,7 @@ from typing import Union, Dict, List
 from deeplake.core.vectorstore.vector_search.indra import query
 from deeplake.core.vectorstore.vector_search import utils
 from deeplake.core.dataset import Dataset as DeepLakeDataset
+from deeplake.enterprise.util import raise_indra_installation_error
 
 
 def search(
@@ -63,6 +64,10 @@ def search(
         )
         return_data = data
     else:
+        if not INDRA_INSTALLED:
+            raise raise_indra_installation_error(
+                indra_import_error=False
+            )  # pragma: no cover
         return_data = {}
 
         view = deeplake_dataset.query(

--- a/deeplake/core/vectorstore/vector_search/indra/search_algorithm.py
+++ b/deeplake/core/vectorstore/vector_search/indra/search_algorithm.py
@@ -40,7 +40,9 @@ def search(
     """
     try:
         from indra import api  # type: ignore
+        INDRA_INSTALLED = True
     except ImportError:
+        INDRA_INSTALLED = False
         pass
 
     if tql_string:


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

- [X] Bug fix (non-breaking change which fixes expected existing functionality)

### Description

Without libdeeplake (indra) installed, for example on Windows, vector search causes exception when exec_option is "tensor_db"

### Additional Context

Traceback of exception without this fix:
```
Traceback (most recent call last):
  File "C:\Program Files\Python310\lib\contextlib.py", line 153, in __exit__
    self.gen.throw(typ, value, traceback)
  File "E:\venv\lib\site-packages\llama_index\callbacks\base.py", line 133, in as_trace
    yield
  File "E:\venv\lib\site-packages\llama_index\indices\query\base.py", line 23, in query
    response = self._query(str_or_query_bundle)
  File "E:\venv\lib\site-packages\llama_index\query_engine\retriever_query_engine.py", line 147, in _query
    nodes = self.retrieve(query_bundle)
  File "E:\venv\lib\site-packages\llama_index\query_engine\retriever_query_engine.py", line 107, in retrieve
    nodes = self._retriever.retrieve(query_bundle)
  File "E:\venv\lib\site-packages\llama_index\indices\base_retriever.py", line 21, in retrieve
    return self._retrieve(str_or_query_bundle)
  File "E:\venv\lib\site-packages\llama_index\indices\vector_store\retrievers\retriever.py", line 85, in _retrieve
    query_result = self._vector_store.query(query, **self._kwargs)
  File "E:\venv\lib\site-packages\llama_index\vector_stores\deeplake.py", line 188, in query
    data = self.vectorstore.search(
  File "E:\venv\lib\site-packages\deeplake\core\vectorstore\deeplake_vectorstore.py", line 433, in search
    return vector_search.search(
  File "E:\venv\lib\site-packages\deeplake\core\vectorstore\vector_search\vector_search.py", line 51, in search
    return EXEC_OPTION_TO_SEARCH_TYPE[exec_option](
  File "E:\venv\lib\site-packages\deeplake\core\vectorstore\vector_search\indra\vector_search.py", line 44, in vector_search
    return vectorstore.indra_search_algorithm(
  File "E:\venv\lib\site-packages\deeplake\core\vectorstore\vector_search\indra\search_algorithm.py", line 41, in search
    from indra import api  # type: ignore
ModuleNotFoundError: No module named 'indra'
```
