### PR TITLE
Read only mode autocasting for VectorStore

### DIFF
--- a/deeplake/core/vectorstore/deeplake_vectorstore.py
+++ b/deeplake/core/vectorstore/deeplake_vectorstore.py
@@ -36,7 +36,7 @@ class VectorStore:
         path: Union[str, pathlib.Path],
         tensor_params: List[Dict[str, object]] = DEFAULT_VECTORSTORE_TENSORS,
         embedding_function: Optional[Callable] = None,
-        read_only: Optional[bool] = False,
+        read_only: Optional[bool] = None,
         ingestion_batch_size: int = 1000,
         num_workers: int = 0,
         exec_option: str = "auto",

--- a/deeplake/core/vectorstore/test_deeplake_vectorstore.py
+++ b/deeplake/core/vectorstore/test_deeplake_vectorstore.py
@@ -1769,3 +1769,8 @@ def test_uuid_fix(local_path):
     vector_store.add(text=texts, id=ids, embedding=embeddings, metadata=metadatas)
 
     assert vector_store.dataset.id.data()["value"] == list(map(str, ids))
+
+
+def test_read_only():
+    db = VectorStore("hub://davitbun/twitter-algorithm")
+    assert db.dataset.read_only == True


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

<!--
A clear and concise description of the change being made.  

The title should introduce what was/will be done
  - Titles show in release notes and search results, so make them useful 
  - Be specific about what was fixed or changed
  - Imagine yourself looking for this PR in 6 months -- what will make it findable and valuable to future you?
  - Good Example: `Correctly apply passed S3 credentials when using VectorStore`
  - Bad Example: `Fixed creds issue`  

The description gives the details on what was/will be done 
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need to know and how the fix will affect them
- Describe how the code change addresses the problem
- Imagine yourself looking for this PR in 6 months -- what will make it findable and valuable to future you?
- Ensure private information is redacted.
-->

### Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

### Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

### Additional Context

<!--
Add any other context about the problem here.
-->


In this PR I'm changing default behavior of Vectorstore read_only, from being be default set to False, not it is set to None, so that later inside of deeplake it could automatically autocast it.
