### PR TITLE
Fixed List[str] annotation in delete_branch feature

### DIFF
--- a/deeplake/util/version_control.py
+++ b/deeplake/util/version_control.py
@@ -369,7 +369,7 @@ def delete_branch(
 
 
 def _delete_branch_and_commits(
-    branch_name: str, all_branch_commits: list[str], dataset, storage
+    branch_name: str, all_branch_commits: List[str], dataset, storage
 ) -> None:
     """
     Physically deletes the given branch and list of commits from the version_control_info.json and versions directories.
@@ -401,7 +401,7 @@ def _delete_branch_and_commits(
     ).encode("utf-8")
 
 
-def _find_branch_commits(branch_name: str, version_state: dict) -> list[str]:
+def _find_branch_commits(branch_name: str, version_state: dict) -> List[str]:
     """
     Returns a list of all commits used by the given branch
     """


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

Fixes type annotation to avoid this error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/s/work/deeplake/deeplake/__init__.py", line 19, in <module>
    from .api.dataset import dataset as api_dataset
  File "/Users/s/work/deeplake/deeplake/api/dataset.py", line 9, in <module>
    from deeplake.auto.unstructured.image_classification import ImageClassification
  File "/Users/s/work/deeplake/deeplake/auto/unstructured/image_classification.py", line 13, in <module>
    from deeplake.core.dataset import Dataset
  File "/Users/s/work/deeplake/deeplake/core/dataset/__init__.py", line 1, in <module>
    from .dataset import Dataset  # type: ignore
  File "/Users/s/work/deeplake/deeplake/core/dataset/dataset.py", line 22, in <module>
    from deeplake.util.version_control import (
  File "/Users/s/work/deeplake/deeplake/util/version_control.py", line 372, in <module>
    branch_name: str, all_branch_commits: list[str], dataset, storage
TypeError: 'type' object is not subscriptable
```

