### PR TITLE
Add progress bar to ds.extend

### DIFF
--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -3030,6 +3030,7 @@ class Dataset:
             skip_ok (bool): Skip tensors not in ``samples`` if set to True.
             append_empty (bool): Append empty samples to tensors not specified in ``sample`` if set to ``True``. If True, ``skip_ok`` is ignored.
             ignore_errors (bool): Skip samples that cause errors while extending, if set to ``True``.
+            progressbar (bool): Displays a progress bar if set to ``True``.
 
         Raises:
             KeyError: If any tensor in the dataset is not a key in ``samples`` and ``skip_ok`` is ``False``.

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -3021,6 +3021,7 @@ class Dataset:
         skip_ok: bool = False,
         append_empty: bool = False,
         ignore_errors: bool = False,
+        progressbar: bool = False,
     ):
         """Appends multiple rows of samples to mutliple tensors at once. This method expects all tensors being updated to be of the same length.
 
@@ -3062,7 +3063,11 @@ class Dataset:
                 samples, extend=True, skip_ok=skip_ok, append_empty=append_empty
             )
         with self:
-            for i in range(n):
+            if progressbar:
+                indices = tqdm(range(n))
+            else:
+                indices = range(n)
+            for i in indices:
                 try:
                     self.append(
                         {k: v[i] for k, v in samples.items()},


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

<!--
A clear and concise description of the change being made.  

The title should introduce what was/will be done
  - Titles show in release notes and search results, so make them useful 
  - Be specific about what was fixed or changed
  - Imagine yourself looking for this PR in 6 months -- what will make it findable and valuable to future you?
  - Good Example: `Correctly apply passed S3 credentials when using VectorStore`
  - Bad Example: `Fixed creds issue`  

The description gives the details on what was/will be done 
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need to know and how the fix will affect them
- Describe how the code change addresses the problem
- Imagine yourself looking for this PR in 6 months -- what will make it findable and valuable to future you?
- Ensure private information is redacted.
-->

### Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

### Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

### Additional Context

<!--
Add any other context about the problem here.
-->
