### PR TITLE
Added _squash_main() method

### DIFF
--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -1772,7 +1772,7 @@ class Dataset:
     def squash_commits(self) -> None:
         """
         Squashes all commits in current branch into one commit.
-        NOTE: This is cannot be run if there are any branches besides `main`
+        NOTE: This cannot be run if there are any branches besides ``main``
 
         Raises:
             ReadOnlyModeError: If branch deletion is attempted in read-only mode.

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -24,7 +24,7 @@ from deeplake.util.version_control import (
     integrity_check,
     save_commit_info,
     rebuild_version_info,
-    squash_commits,
+    _squash_main,
 )
 from deeplake.util.invalid_view_op import invalid_view_op
 from deeplake.util.spinner import spinner
@@ -1769,8 +1769,10 @@ class Dataset:
             self.storage.autoflush = self._initial_autoflush.pop()
 
     @invalid_view_op
-    def squash_commits(self) -> None:
+    def _squash_main(self) -> None:
         """
+        DEPRECATED: This method is deprecated and will be removed in a future release.
+
         Squashes all commits in current branch into one commit.
         NOTE: This cannot be run if there are any branches besides ``main``
 
@@ -1792,7 +1794,7 @@ class Dataset:
         self.storage.autoflush = False
         try:
             self._unlock()
-            squash_commits(self)
+            _squash_main(self)
         finally:
             self._set_read_only(read_only, err=True)
             self.libdeeplake_dataset = None

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -1771,12 +1771,12 @@ class Dataset:
     @invalid_view_op
     def squash_commits(self) -> None:
         """
-        Squashes all commits in 'main' into one commit.
-        This is cannot be run if there are any branches besides `main`
+        Squashes all commits in current branch into one commit.
+        NOTE: This is cannot be run if there are any branches besides `main`
 
         Raises:
             ReadOnlyModeError: If branch deletion is attempted in read-only mode.
-            VersionControlError: If the main branch cannot be squashed.
+            VersionControlError: If the branch cannot be squashed.
         """
         if self._is_filtered_view:
             raise Exception(
@@ -1795,6 +1795,7 @@ class Dataset:
             squash_commits(self)
         finally:
             self._set_read_only(read_only, err=True)
+            self.libdeeplake_dataset = None
             self.storage.autoflush = self._initial_autoflush.pop()
 
     def log(self):

--- a/deeplake/core/version_control/test_version_control.py
+++ b/deeplake/core/version_control/test_version_control.py
@@ -2568,6 +2568,7 @@ def test_squash_main_has_branch(local_ds_generator):
         local_ds._squash_main()
     assert "Cannot squash commits if there are multiple branches" in str(e.value)
 
+
 def test_squash_main_has_view(local_ds_generator):
     local_ds = local_ds_generator()
     local_ds.create_tensor("test")
@@ -2580,6 +2581,7 @@ def test_squash_main_has_view(local_ds_generator):
     with pytest.raises(VersionControlError) as e:
         local_ds._squash_main()
     assert "Cannot squash commits if there are views present" in str(e.value)
+
 
 def test_squash_main(local_ds_generator):
     local_ds = local_ds_generator()
@@ -2615,7 +2617,9 @@ def test_squash_main(local_ds_generator):
     local_ds._squash_main()
 
     assert len(local_ds.branches) == 1
-    assert len(glob.glob(local_ds.path + "/versions/*")) == 0
+    assert len(glob.glob(local_ds.path + "/versions/*")) == 1
+    assert [commit["message"] for commit in local_ds.commits] == ["Squashed commits"]
+    assert local_ds.pending_commit_id != FIRST_COMMIT_ID
 
     with open(local_ds.path + "/version_control_info.json", "r") as f:
         data = json.load(f)
@@ -2633,7 +2637,5 @@ def test_squash_main(local_ds_generator):
         "main 4",
         "main uncommitted",
     ]
-    assert [i["message"] for i in local_ds.commits] == []
-    assert local_ds.commit_id == None
-    assert local_ds.pending_commit_id == FIRST_COMMIT_ID
-
+    assert [i["message"] for i in local_ds.commits] == ["Squashed commits"]
+    assert local_ds.pending_commit_id != FIRST_COMMIT_ID

--- a/deeplake/core/version_control/test_version_control.py
+++ b/deeplake/core/version_control/test_version_control.py
@@ -1,5 +1,9 @@
 import glob
+import json
 from collections import OrderedDict
+
+from deeplake.constants import FIRST_COMMIT_ID
+
 import deeplake
 import pytest
 import numpy as np
@@ -2550,3 +2554,60 @@ def test_branch_delete(local_ds_generator):
 
     local_ds.delete_branch("alt1_sub1")
     assert len(local_ds.branches) == 2
+
+
+def test_branch_squash(local_ds_generator):
+    local_ds = local_ds_generator()
+    local_ds.create_tensor("test")
+
+    with local_ds:
+        # Add commits to main
+        local_ds.test.append("main 1")
+        local_ds.test.append("main 2")
+        local_ds.commit("first main commit")
+        local_ds.test.append("main 3")
+        local_ds.commit("second main commit")
+        local_ds.test.append("main 4")
+        local_ds.commit("third main commit")
+        local_ds.test.append("main uncommitted")
+
+    assert len(local_ds.branches) == 1
+    assert len(glob.glob(local_ds.path + "/versions/*")) > 0
+    assert len(local_ds.test) == 5
+    assert [i.data()["value"] for i in local_ds.test] == [
+        "main 1",
+        "main 2",
+        "main 3",
+        "main 4",
+        "main uncommitted",
+    ]
+    assert [i["message"] for i in local_ds.commits] == [
+        "third main commit",
+        "second main commit",
+        "first main commit",
+    ]
+
+    local_ds.squash_commits()
+
+    assert len(local_ds.branches) == 1
+    assert len(glob.glob(local_ds.path + "/versions/*")) == 0
+
+    with open(local_ds.path + "/version_control_info.json", "r") as f:
+        data = json.load(f)
+        assert len(data["commits"]) == 1
+        assert data["commits"][FIRST_COMMIT_ID]["commit_message"] == None
+        assert data["commits"][FIRST_COMMIT_ID]["commit_time"] == None
+        assert data["commits"][FIRST_COMMIT_ID]["commit_user_name"] == None
+        assert len(data["commits"][FIRST_COMMIT_ID]["children"]) == 0
+        assert data["commits"][FIRST_COMMIT_ID]["parent"] == None
+
+    assert [i.data()["value"] for i in local_ds.test] == [
+        "main 1",
+        "main 2",
+        "main 3",
+        "main 4",
+        "main uncommitted",
+    ]
+    assert [i["message"] for i in local_ds.commits] == []
+    assert local_ds.commit_id == None
+    assert local_ds.pending_commit_id == FIRST_COMMIT_ID

--- a/deeplake/util/version_control.py
+++ b/deeplake/util/version_control.py
@@ -42,7 +42,8 @@ from deeplake.util.keys import (
     get_version_control_info_key,
     get_version_control_info_key_old,
     get_version_control_info_lock_key,
-    get_commit_info_key, get_pad_encoder_key,
+    get_commit_info_key,
+    get_pad_encoder_key,
 )
 from deeplake.constants import COMMIT_INFO_FILENAME
 from deeplake.util.remove_cache import get_base_storage
@@ -306,9 +307,7 @@ def _squash_main(
             f"Cannot squash commits if there are multiple branches"
         )
     if len(dataset.get_views()) > 0:
-        raise VersionControlError(
-            f"Cannot squash commits if there are views present"
-        )
+        raise VersionControlError(f"Cannot squash commits if there are views present")
 
     try:
         base_storage = get_base_storage(storage)
@@ -336,7 +335,6 @@ def _squash_main(
                         )
                     ] = chunk.tobytes()
 
-
             for key_fn in [
                 get_tensor_info_key,
                 get_tensor_meta_key,
@@ -347,12 +345,13 @@ def _squash_main(
                 get_tensor_tile_encoder_key,
             ]:
                 try:
-                    data_bytes = storage.get_bytes(key_fn(chunk_engine.key, dataset.pending_commit_id))
+                    data_bytes = storage.get_bytes(
+                        key_fn(chunk_engine.key, dataset.pending_commit_id)
+                    )
                 except KeyError:
                     continue
 
                 base_storage[key_fn(chunk_engine.key, FIRST_COMMIT_ID)] = data_bytes
-
 
         commits_to_delete = [
             commit_id
@@ -389,6 +388,8 @@ def _squash_main(
             delete_version_from_storage(dataset.storage, commit_to_delete)
 
         dataset._reload_version_state()
+
+        dataset.commit("Squashed commits")
 
     finally:
         versioncontrol_lock.release()

--- a/deeplake/util/version_control.py
+++ b/deeplake/util/version_control.py
@@ -290,7 +290,7 @@ def checkout(
         ) from e
 
 
-def squash_commits(
+def _squash_main(
     dataset,
 ) -> None:
     """
@@ -305,6 +305,11 @@ def squash_commits(
         raise VersionControlError(
             f"Cannot squash commits if there are multiple branches"
         )
+    if len(dataset.get_views()) > 0:
+        raise VersionControlError(
+            f"Cannot squash commits if there are views present"
+        )
+
     try:
         base_storage = get_base_storage(storage)
         versioncontrol_lock = PersistentLock(

--- a/deeplake/util/version_control.py
+++ b/deeplake/util/version_control.py
@@ -4,6 +4,9 @@ import hashlib
 import pickle
 from typing import Any, Dict, Optional, List
 import warnings
+
+from deeplake.core.meta.encode.chunk_id import ChunkIdEncoder
+
 from deeplake.client.log import logger
 from deeplake.constants import FIRST_COMMIT_ID
 from deeplake.core import lock
@@ -285,6 +288,108 @@ def checkout(
         raise CheckoutError(
             f"Unable to checkout to '{address}', failed to load meta data."
         ) from e
+
+
+def squash_commits(
+    dataset,
+) -> None:
+    """
+    Combines all commits in the main branch into a single commit.
+    """
+    storage = dataset.storage
+    storage.check_readonly()
+
+    # storage = dataset.storage
+    version_state = dataset.version_state
+
+    if len(dataset.branches) > 1:
+        raise VersionControlError(
+            f"Cannot squash commits if there are multiple branches"
+        )
+    try:
+        base_storage = get_base_storage(storage)
+        versioncontrol_lock = PersistentLock(
+            base_storage, get_version_control_info_lock_key()
+        )
+        versioncontrol_lock.acquire()  # Blocking
+
+        dataset_lock = lock.lock_dataset(dataset, dataset.branches[0])
+
+        for tensor in dataset._tensors(
+            include_hidden=True, include_disabled=True
+        ).values():
+            chunk_engine = tensor.chunk_engine
+            for chunk_id in [row[0] for row in chunk_engine.chunk_id_encoder._encoded]:
+                chunk = chunk_engine.get_chunk_from_chunk_id(chunk_id)
+                if chunk.key.startswith("versions"):
+                    base_storage[
+                        "/".join(
+                            [
+                                tensor.key,
+                                "chunks",
+                                ChunkIdEncoder.name_from_id(chunk_id),
+                            ]
+                        )
+                    ] = chunk.tobytes()
+
+            base_storage[
+                get_chunk_id_encoder_key(chunk_engine.key, FIRST_COMMIT_ID)
+            ] = storage.get_bytes(
+                get_chunk_id_encoder_key(chunk_engine.key, dataset.pending_commit_id)
+            )
+            base_storage[
+                get_tensor_tile_encoder_key(chunk_engine.key, FIRST_COMMIT_ID)
+            ] = storage.get_bytes(
+                get_tensor_tile_encoder_key(chunk_engine.key, dataset.pending_commit_id)
+            )
+            base_storage[
+                get_tensor_meta_key(chunk_engine.key, FIRST_COMMIT_ID)
+            ] = storage.get_bytes(
+                get_tensor_meta_key(chunk_engine.key, dataset.pending_commit_id)
+            )
+            # print(tensor.key, chunk_engine.chunk_id_encoder.name_from_id(chunk_id))
+
+        commits_to_delete = [
+            commit_id
+            for commit_id in version_state["commit_node_map"].keys()
+            if commit_id != FIRST_COMMIT_ID
+        ]
+
+        dataset.version_state["commit_node_map"] = {
+            FIRST_COMMIT_ID: dataset.version_state["commit_node_map"][FIRST_COMMIT_ID],
+        }
+        dataset.version_state["commit_node_map"][FIRST_COMMIT_ID].children = []
+        dataset.version_state["commit_node_map"][FIRST_COMMIT_ID].commit_message = None
+        dataset.version_state["commit_node_map"][FIRST_COMMIT_ID].commit_time = None
+        dataset.version_state["commit_node_map"][
+            FIRST_COMMIT_ID
+        ].commit_user_name = None
+
+        dataset.version_state["branch_commit_map"]["main"] = FIRST_COMMIT_ID
+        dataset.version_state["commit_id"] = FIRST_COMMIT_ID
+        dataset.version_state["commit_node"] = dataset.version_state["commit_node_map"][
+            FIRST_COMMIT_ID
+        ]
+
+        base_storage[get_version_control_info_key()] = json.dumps(
+            _version_info_to_json(
+                {
+                    "commit_node_map": version_state["commit_node_map"],
+                    "branch_commit_map": version_state["branch_commit_map"],
+                }
+            )
+        ).encode("utf-8")
+
+        for commit_to_delete in commits_to_delete:
+            delete_version_from_storage(dataset.storage, commit_to_delete)
+
+        dataset._reload_version_state()
+
+    finally:
+        versioncontrol_lock.release()
+        dataset_lock and dataset_lock.release()
+    #
+    # dataset._send_branch_deletion_event(branch_name)
 
 
 def delete_branch(


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

Creates a new `dataset._squash_main()` method which squashes all the commits in main into a single commit. 

It moves the latest versions of the chunk files and other metadata files from the various existing commits up to the head commit (for now, FIRST_COMMIT_ID), updates the version_control_info.json file to no longer reference the old commits, and deletes the old version directories. The end result is a single commit with the message "Squashed commits" and a new staging version for future changes. 

### Things to be aware of

It only supports squashing commits on the main branch, and only when there are no other branches and when there are no views.

This keeps the logic safer and simpler, and given that the reason for the feature right now is for people who had a bunch of commits auto-generated for them and they don't really care about version control and don't want the overhead of the extra commits. 

We went with the `_squash_main()` name vs. some thing more future-extendable because this is likely not something we will want to support in the future and it's better to design it to be small-scoped and removed than larger-future-scoped and kept around.

### Things to worry about

**It deletes data from `versions` which is always a bit scary.** Is there any data that's not correctly copied over that will be lost? Anything with the tiles or anything that will be lost? **_Answer is "no"_**

### Additional Context

<!--
Add any other context about the problem here.
-->
