### PR TITLE
Read only expected tensor length from data buffer into numpy array

### DIFF
--- a/deeplake/core/chunk_engine.py
+++ b/deeplake/core/chunk_engine.py
@@ -2054,7 +2054,7 @@ class ChunkEngine:
                     dtype = self.tensor_meta.dtype
 
                     data_bytes = bytearray(chunk.data_bytes)
-                    self.cached_data = np.frombuffer(data_bytes, dtype).reshape(
+                    self.cached_data = np.frombuffer(data_bytes, dtype, self.tensor_meta.length).reshape(
                         full_shape
                     )
                     self.cache_range = range(first_sample, last_sample + 1)

--- a/deeplake/core/chunk_engine.py
+++ b/deeplake/core/chunk_engine.py
@@ -2054,7 +2054,12 @@ class ChunkEngine:
                     dtype = self.tensor_meta.dtype
 
                     data_bytes = bytearray(chunk.data_bytes)
-                    self.cached_data = np.frombuffer(data_bytes, dtype, self.tensor_meta.length).reshape(
+
+                    length_to_read = 1
+                    for dim in full_shape:
+                        length_to_read = length_to_read * dim
+
+                    self.cached_data = np.frombuffer(data_bytes, dtype, length_to_read).reshape(
                         full_shape
                     )
                     self.cache_range = range(first_sample, last_sample + 1)


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

Some data chunks can have unexpected data stored in them which causes  the conversion to a numpy array to fail.

Limit the data read from the buffer to be just the needed length to avoid exceptions like: `ValueError: cannot reshape array of size 5744 into shape (2872,1)`


### Things to be aware of

There really shouldn't be unexpected data, so need to watch for the upstream cause in the future. 

I was hoping to warn about the mismatch between stored data and the tensor length, but I didn't see a good way to get the expected number of bytes numpy would use given the dtype name in order to compute if there is a surprise. So didn't end up with a warning.

### Things to worry about

Nothing
