### PR TITLE
Fix support for deeplake.random.seed() on python 3.9 and earlier

### DIFF
--- a/deeplake/core/seed.py
+++ b/deeplake/core/seed.py
@@ -11,7 +11,7 @@ class DeeplakeRandom(object):
 
 
     def seed(self, seed: Optional[int] = None):
-        if isinstance(seed, Optional[int]):
+        if isinstance(seed, int):
             self.internal_seed = seed
             if self.indra_api is None:
                 from deeplake.enterprise.convert_to_libdeeplake import import_indra_api_silent

--- a/deeplake/core/seed.py
+++ b/deeplake/core/seed.py
@@ -11,7 +11,7 @@ class DeeplakeRandom(object):
 
 
     def seed(self, seed: Optional[int] = None):
-        if isinstance(seed, int):
+        if seed is None or isinstance(seed, int):
             self.internal_seed = seed
             if self.indra_api is None:
                 from deeplake.enterprise.convert_to_libdeeplake import import_indra_api_silent
@@ -19,7 +19,7 @@ class DeeplakeRandom(object):
             if self.indra_api is not None:
                 self.indra_api.set_seed(self.internal_seed)
         else:
-            raise TypeError(f"provided seed type `{type(seed)}` is increect seed must be an integer")
+            raise TypeError(f"provided seed type `{type(seed)}` is incorrect seed must be an integer")
 
     def get_seed(self) -> Optional[int]:
         return self.internal_seed

--- a/deeplake/core/tests/test_seed.py
+++ b/deeplake/core/tests/test_seed.py
@@ -1,0 +1,17 @@
+import pytest
+
+from deeplake import DeeplakeRandom
+
+
+@pytest.mark.parametrize("input", [1234, None])
+def test_seed(input):
+    obj = DeeplakeRandom()
+    obj.seed(input)
+
+    assert obj.get_seed() == input
+
+@pytest.mark.parametrize("input", [1.3, "a string"])
+def test_invalid_seed(input):
+    obj = DeeplakeRandom()
+    with pytest.raises(TypeError):
+        obj.seed(input)


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

#2537 introduced the ability to specify a seed for random algorithms used in Deeplake, but it caused a `TypeError` to be thrown in Python 3.9 and earlier due to difference in support in `isinstance(..., Optional[int])`

### Things to be aware of

Works fine with 3.10+

### Things to worry about

Nothing

