### PR TITLE
Set default embedding htype to float32

### DIFF
--- a/deeplake/api/tests/test_api.py
+++ b/deeplake/api/tests/test_api.py
@@ -682,7 +682,7 @@ def test_htype(memory_ds: Dataset):
     # Along the first direcection three matrices are concatenated, the first matrix is P,
     # the second one is Tr and the third one is R
     intrinsics.append(np.zeros((3, 4, 4), dtype=np.float32))
-    embedding.append(np.random.rand((100)))
+    embedding.append(np.random.rand((100)).astype(np.float32))
 
 
 def test_dtype(memory_ds: Dataset):

--- a/deeplake/api/tests/test_api.py
+++ b/deeplake/api/tests/test_api.py
@@ -2926,7 +2926,7 @@ def test_change_htype(local_ds_generator):
         ds.boxes_3d.extend(np.random.randn(10, 5, 8))
 
         ds.create_tensor("embeddings")
-        ds.embeddings.extend(np.random.randn(10, 1536))
+        ds.embeddings.extend(np.random.randn(10, 1536).astype(np.float32))
 
         mask = np.zeros((10, 100, 100, 5), dtype=bool)
         mask[:, :, :512, 1] = 1
@@ -2993,6 +2993,12 @@ def test_change_htype_fail(local_ds_generator):
             ds.boxes2.htype = "bbox"
         with pytest.raises(IncompatibleHtypeError):
             ds.boxes2.htype = "bbox.3d"
+
+        # bad dtype
+        ds.create_tensor("embeddings")
+        ds.embeddings.extend(np.zeros((1, 1536)))
+        with pytest.raises(IncompatibleHtypeError):
+            ds.embeddings.htype = "embedding"
 
         ds.create_tensor("masks")
         ds.masks.extend(np.zeros((10, 5, 5, 5, 5)))

--- a/deeplake/core/vectorstore/test_deeplake_vectorstore.py
+++ b/deeplake/core/vectorstore/test_deeplake_vectorstore.py
@@ -86,7 +86,7 @@ def test_id_backward_compatibility(local_path):
     embedding_dim = 100
 
     ids = [f"{i}" for i in range(num_of_items)]
-    embedding = [np.zeros(embedding_dim) for i in range(num_of_items)]
+    embedding = [np.zeros(embedding_dim, dtype=np.float32) for i in range(num_of_items)]
     text = ["aadfv" for i in range(num_of_items)]
     metadata = [{"key": i} for i in range(num_of_items)]
 

--- a/deeplake/htype.py
+++ b/deeplake/htype.py
@@ -69,7 +69,7 @@ HTYPE_CONFIGURATIONS: Dict[str, Dict] = {
     htype.BBOX: {"dtype": "float32", "coords": {}, "_info": ["coords"]},
     htype.BBOX_3D: {"dtype": "float32", "coords": {}, "_info": ["coords"]},
     htype.AUDIO: {"dtype": "float64"},
-    htype.EMBEDDING: {},
+    htype.EMBEDDING: {"dtype": "float32"},
     htype.VIDEO: {"dtype": "uint8"},
     htype.BINARY_MASK: {
         "dtype": "bool"
@@ -119,7 +119,6 @@ class constraints:
         lambda htype, dtype: f"Incompatible dtype of tensor for htype {htype}: {dtype}"
     )
 
-    EMBEDDING = lambda shape, dtype: True
     INSTANCE_LABEL = lambda shape, dtype: True
 
     @staticmethod
@@ -149,6 +148,11 @@ class constraints:
             raise IncompatibleHtypeError(constraints.ndim_error("bbox.3d", len(shape)))
         if shape[-1] != 8:
             raise IncompatibleHtypeError(constraints.shape_error("bbox.3d", shape))
+
+    @staticmethod
+    def EMBEDDING(shape, dtype):
+        if dtype != np.float32:
+            raise IncompatibleHtypeError(constraints.dtype_error("embedding", dtype))
 
     @staticmethod
     def BINARY_MASK(shape, dtype):


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

<!--
A clear and concise description of the change being made.  

The title should introduce what was/will be done
  - Titles show in release notes and search results, so make them useful 
  - Be specific about what was fixed or changed
  - Imagine yourself looking for this PR in 6 months -- what will make it findable and valuable to future you?
  - Good Example: `Correctly apply passed S3 credentials when using VectorStore`
  - Bad Example: `Fixed creds issue`  

The description gives the details on what was/will be done 
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need to know and how the fix will affect them
- Describe how the code change addresses the problem
- Imagine yourself looking for this PR in 6 months -- what will make it findable and valuable to future you?
- Ensure private information is redacted.
-->

### Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

### Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

### Additional Context

<!--
Add any other context about the problem here.
-->
