### PR TITLE
Removed typing_extensions usage

### DIFF
--- a/deeplake/util/path.py
+++ b/deeplake/util/path.py
@@ -2,8 +2,6 @@ import pathlib
 import posixpath
 from typing import Optional, Union, Tuple, Dict
 
-from typing_extensions import LiteralString
-
 from deeplake.core.storage.provider import StorageProvider
 from deeplake.util.tag import process_hub_path
 from deeplake.constants import HUB_CLOUD_DEV_USERNAME
@@ -14,7 +12,7 @@ import re
 
 CLOUD_DS_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]*$")
 LOCAL_DS_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_ .-]*$")
-_relpath_cache: Dict[str, LiteralString] = {}
+_relpath_cache: Dict[str, str] = {}
 
 
 def is_hub_cloud_path(path: str):


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

`typing_extensions` should not be a dependency of deeplake, and no need to add it.

With the current code, unless a user manually installs typing_extensions, they get the error:

```
File ~/Documents/code/activeloop_index/deeplake/deeplake/util/path.py:5
      2 import posixpath
      3 from typing import Optional, Union, Tuple, Dict
----> 5 from typing_extensions import LiteralString
      7 from deeplake.core.storage.provider import StorageProvider
      8 from deeplake.util.tag import process_hub_path

ModuleNotFoundError: No module named 'typing_extensions'
```

### Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

### Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

### Additional Context

<!--
Add any other context about the problem here.
-->
