### PR TITLE
Added sample_indices() to virtual tensor and dataset.

### DIFF
--- a/deeplake/core/dataset/deeplake_query_dataset.py
+++ b/deeplake/core/dataset/deeplake_query_dataset.py
@@ -284,6 +284,15 @@ class DeepLakeQueryDataset(Dataset):
     def index(self):
         return self._index
 
+    @property
+    def sample_indices(self):
+        for t in self.tensors.values():
+            try:
+                return t.indra_tensor.indexes
+            except RuntimeError:
+                pass
+        return range(self.num_samples)
+
     def _tensors(
         self, include_hidden: bool = True, include_disabled=True
     ) -> Dict[str, Tensor]:

--- a/deeplake/core/dataset/deeplake_query_tensor.py
+++ b/deeplake/core/dataset/deeplake_query_tensor.py
@@ -138,6 +138,13 @@ class DeepLakeQueryTensor(tensor.Tensor):
         raise NotImplementedError("Virtual tensor does not have chunk engine.")
 
     @property
+    def sample_indices(self):
+        try:
+            return self.indra_tensor.indexes
+        except RuntimeError:
+            return range(self.num_samples)
+
+    @property
     def shape(self):
         if (
             not self.indra_tensor.is_sequence

--- a/deeplake/core/tests/test_deeplake_indra_dataset.py
+++ b/deeplake/core/tests/test_deeplake_indra_dataset.py
@@ -424,7 +424,7 @@ def test_virtual_tensors(local_auth_ds_generator):
             np.sqrt(2.0 / (i + 1) / (i + 1))
         ]
 
-    assert deeplake_indra_ds.sample_indices == range(100)
+    assert deeplake_indra_ds.sample_indices == slice(0, 100, 1)
     deeplake_indra_ds = deeplake_ds.query(
         "SELECT *, l2_norm(embeddings - ARRAY[0, 0, 0]) as score order by l2_norm(embeddings - ARRAY[0, 0, 0]) asc"
     )
@@ -432,4 +432,4 @@ def test_virtual_tensors(local_auth_ds_generator):
     assert list(deeplake_indra_ds.embeddings.sample_indices) == list(
         reversed(range(100))
     )
-    assert list(deeplake_indra_ds.score.sample_indices) == list(range(100))
+    assert deeplake_indra_ds.score.sample_indices == slice(0, 100, 1)

--- a/deeplake/core/tests/test_deeplake_indra_dataset.py
+++ b/deeplake/core/tests/test_deeplake_indra_dataset.py
@@ -423,3 +423,13 @@ def test_virtual_tensors(local_auth_ds_generator):
         assert deeplake_indra_ds.score[100 - i].numpy() == [
             np.sqrt(2.0 / (i + 1) / (i + 1))
         ]
+
+    assert deeplake_indra_ds.sample_indices == range(100)
+    deeplake_indra_ds = deeplake_ds.query(
+        "SELECT *, l2_norm(embeddings - ARRAY[0, 0, 0]) as score order by l2_norm(embeddings - ARRAY[0, 0, 0]) asc"
+    )
+    assert list(deeplake_indra_ds.sample_indices) == list(reversed(range(100)))
+    assert list(deeplake_indra_ds.embeddings.sample_indices) == list(
+        reversed(range(100))
+    )
+    assert list(deeplake_indra_ds.score.sample_indices) == list(range(100))


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

<!--
A clear and concise description of the change being made.  

The title should introduce what was/will be done
  - Titles show in release notes and search results, so make them useful 
  - Be specific about what was fixed or changed
  - Imagine yourself looking for this PR in 6 months -- what will make it findable and valuable to future you?
  - Good Example: `Correctly apply passed S3 credentials when using VectorStore`
  - Bad Example: `Fixed creds issue`  

The description gives the details on what was/will be done 
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need to know and how the fix will affect them
- Describe how the code change addresses the problem
- Imagine yourself looking for this PR in 6 months -- what will make it findable and valuable to future you?
- Ensure private information is redacted.
-->

### Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

### Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

### Additional Context

<!--
Add any other context about the problem here.
-->
