### PR TITLE
Disable huggingface tests on MacOS

### DIFF
--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -66,7 +66,7 @@ jobs:
                       ]
                   }
           
-              if "${{ contains(github.event.pull_request.labels.*.name, 'macos-tests') }}" == "true":
+              if "${{ contains(github.event.pull_request.labels.*.name, 'test-macos') }}" == "true":
                   matrix["os"].append("macos-latest")
 
               if "${{ contains(github.event.pull_request.labels.*.name, 'full-tests') }}" == "true":

--- a/deeplake/integrations/tests/test_huggingface.py
+++ b/deeplake/integrations/tests/test_huggingface.py
@@ -1,3 +1,12 @@
+import pytest
+import sys
+
+if sys.platform == "darwin":
+    pytest.skip(
+        "skipping tests on macos due to issue with pyarrow + our aws usage https://github.com/aws/aws-sdk-cpp/issues/2411",
+        allow_module_level=True,
+    )
+
 from datasets import load_dataset  # type: ignore
 from datasets import Dataset  # type: ignore
 from deeplake.api.tests.test_api import convert_string_to_pathlib_if_needed
@@ -6,7 +15,6 @@ from deeplake.integrations.huggingface.huggingface import _is_seq_convertible
 from deeplake.util.exceptions import TensorAlreadyExistsError
 from numpy.testing import assert_array_equal
 
-import pytest
 import deeplake
 
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Build change


### Description

An incompatibility between pyarrow and libdeeplake with the AWS client is causing the macos build to fail. Pyarrow gets used in the huggingface integration only, so disabled those tests on macos to avoid the failure.
