### PR TITLE
Fix `.data()` for empty tensors

### DIFF
--- a/deeplake/api/tests/test_json.py
+++ b/deeplake/api/tests/test_json.py
@@ -245,3 +245,10 @@ def test_list_transform(ds, scheduler="threaded"):
     assert ds.list.data()["value"] == items
     assert ds.list[0].list() == items[0]
     assert ds.list.list() == items
+
+
+def test_empty_json(memory_ds):
+    with memory_ds as ds:
+        ds.create_tensor("json", htype="json")
+
+    assert ds.json.data()["value"] == []

--- a/deeplake/api/tests/test_text.py
+++ b/deeplake/api/tests/test_text.py
@@ -95,3 +95,10 @@ def test_text_tensor_append(memory_ds):
         for i in range(3):
             assert ds.x[i].data() == ds2.x[i].data()
             assert ds.y[i].data() == ds2.y[i].data()
+
+
+def test_empty_text(memory_ds):
+    with memory_ds as ds:
+        ds.create_tensor("text", htype="text")
+
+    assert ds.text.data()["value"] == []

--- a/deeplake/core/tensor.py
+++ b/deeplake/core/tensor.py
@@ -1428,9 +1428,17 @@ class Tensor:
             raise Exception(f"Only supported for {htype} tensors.")
 
         if self.ndim == 1:
-            return self.numpy(fetch_chunks=fetch_chunks)[0]
+            data = self.numpy(fetch_chunks=fetch_chunks)
+            if len(data) == 0:
+                return []
+            else:
+                return data[0]
         else:
-            return [sample[0] for sample in self.numpy(aslist=True)]
+            data = self.numpy(aslist=True, fetch_chunks=fetch_chunks)
+            if len(data) == 0:
+                return []
+            else:
+                return [sample[0] for sample in data]
 
     def text(self, fetch_chunks: bool = False):
         """Return text data. Only applicable for tensors with 'text' base htype."""


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description
- `.data()` should return empty list for `text` and `json` htypes.
<!--
A clear and concise description of the change being made.  

The title should introduce what was/will be done
  - Titles show in release notes and search results, so make them useful 
  - Be specific about what was fixed or changed
  - Imagine yourself looking for this PR in 6 months -- what will make it findable and valuable to future you?
  - Good Example: `Correctly apply passed S3 credentials when using VectorStore`
  - Bad Example: `Fixed creds issue`  

The description gives the details on what was/will be done 
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need to know and how the fix will affect them
- Describe how the code change addresses the problem
- Imagine yourself looking for this PR in 6 months -- what will make it findable and valuable to future you?
- Ensure private information is redacted.
-->

### Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

### Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

### Additional Context

<!--
Add any other context about the problem here.
-->
