### PR TITLE
Fixing failing windows tests

### DIFF
--- a/deeplake/core/vectorstore/test_deeplake_vectorstore.py
+++ b/deeplake/core/vectorstore/test_deeplake_vectorstore.py
@@ -1320,6 +1320,7 @@ def create_and_populate_vs(
     return vector_store
 
 
+@requires_libdeeplake
 def test_update_embedding_row_ids_and_ids_specified_should_throw_exception(
     local_path,
     vector_store_hash_ids,
@@ -1343,6 +1344,7 @@ def test_update_embedding_row_ids_and_ids_specified_should_throw_exception(
         )
 
 
+@requires_libdeeplake
 def test_update_embedding_row_ids_and_filter_specified_should_throw_exception(
     local_path,
     vector_store_filters,
@@ -2837,6 +2839,7 @@ def test_dataset_init_param(local_ds):
     assert len(db) == 10
 
 
+@requires_libdeeplake
 def test_vs_commit(local_path):
     # TODO: add index params, when index will support commit
     db = create_and_populate_vs(


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description


Currently there are 3 windows tests failing on main (fixing those by adding libdeeplake decorator):


```
deeplake/core/vectorstore/test_deeplake_vectorstore.py::test_update_embedding_row_ids_and_ids_specified_should_throw_exception - ImportError: High performance features require the libdeeplake package which is not available in Windows OS
deeplake/core/vectorstore/test_deeplake_vectorstore.py::test_update_embedding_row_ids_and_filter_specified_should_throw_exception - ImportError: High performance features require the libdeeplake package which is not available in Windows OS
deeplake/core/vectorstore/test_deeplake_vectorstore.py::test_vs_commit - ImportError: High performance features require the libdeeplake package which is not available in Windows OS
