### PR TITLE
Better handle when num_workers is passed to deeplake_vectorstore

### DIFF
--- a/deeplake/core/vectorstore/deeplake_vectorstore.py
+++ b/deeplake/core/vectorstore/deeplake_vectorstore.py
@@ -108,7 +108,7 @@ class VectorStore:
             Setting ``overwrite`` to ``True`` will delete all of your data if the Vector Store exists! Be very careful when setting this parameter.
         """
 
-        del kwargs["num_workers"]
+        kwargs.pop("num_workers", None)
 
         self.dataset_handler = get_dataset_handler(
             path=path,

--- a/deeplake/core/vectorstore/deeplake_vectorstore.py
+++ b/deeplake/core/vectorstore/deeplake_vectorstore.py
@@ -107,6 +107,9 @@ class VectorStore:
         Danger:
             Setting ``overwrite`` to ``True`` will delete all of your data if the Vector Store exists! Be very careful when setting this parameter.
         """
+
+        del kwargs["num_workers"]
+
         self.dataset_handler = get_dataset_handler(
             path=path,
             dataset=dataset,


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

The not-yet-released PR #2735 removed `num_workers_from the argument list, but existing code such as the llama-index integration may pass it along still.

The argument would go into the kwargs and then confict/duplicate with our explicitly-set `num_workers=0` argument.

This PR removes the value from kwargs if set. 

### Things to be aware of

Completes the work for #2735, the fix isn't needed for any existing deeplake releases.