### PR TITLE
Ensure filename remains set for later saving in sample_info

### DIFF
--- a/deeplake/core/chunk/sample_compressed_chunk.py
+++ b/deeplake/core/chunk/sample_compressed_chunk.py
@@ -53,8 +53,15 @@ class SampleCompressedChunk(BaseChunk):
                     num_samples += 1
                 else:
                     if serialized_sample:
+                        path = None
+                        if isinstance(incoming_sample, Sample):
+                            path = incoming_sample.path
                         sample = Sample(
-                            buffer=serialized_sample, compression=compr, shape=shape, dtype=dtype, path=incoming_sample.path  # type: ignore
+                            buffer=serialized_sample,
+                            compression=compr,
+                            shape=shape,
+                            dtype=dtype,
+                            path=path  # type: ignore
                         )
                         sample.htype = self.htype
                         incoming_samples[i] = sample

--- a/deeplake/core/chunk/sample_compressed_chunk.py
+++ b/deeplake/core/chunk/sample_compressed_chunk.py
@@ -61,7 +61,7 @@ class SampleCompressedChunk(BaseChunk):
                             compression=compr,
                             shape=shape,
                             dtype=dtype,
-                            path=path  # type: ignore
+                            path=path,  # type: ignore
                         )
                         sample.htype = self.htype
                         incoming_samples[i] = sample

--- a/deeplake/core/chunk/sample_compressed_chunk.py
+++ b/deeplake/core/chunk/sample_compressed_chunk.py
@@ -56,6 +56,7 @@ class SampleCompressedChunk(BaseChunk):
                         path = None
                         if isinstance(incoming_sample, Sample):
                             path = incoming_sample.path
+
                         sample = Sample(
                             buffer=serialized_sample,
                             compression=compr,

--- a/deeplake/core/chunk/sample_compressed_chunk.py
+++ b/deeplake/core/chunk/sample_compressed_chunk.py
@@ -54,7 +54,7 @@ class SampleCompressedChunk(BaseChunk):
                 else:
                     if serialized_sample:
                         sample = Sample(
-                            buffer=serialized_sample, compression=compr, shape=shape, dtype=dtype  # type: ignore
+                            buffer=serialized_sample, compression=compr, shape=shape, dtype=dtype, path=incoming_sample.path  # type: ignore
                         )
                         sample.htype = self.htype
                         incoming_samples[i] = sample

--- a/deeplake/core/sample.py
+++ b/deeplake/core/sample.py
@@ -19,6 +19,7 @@ from deeplake.compression import (
     POINT_CLOUD_COMPRESSION,
     MESH_COMPRESSION,
     NIFTI_COMPRESSION,
+    BYTE_COMPRESSION,
 )
 from deeplake.util.exceptions import SampleReadError, UnableToReadFromUrlError
 from deeplake.util.exif import getexif
@@ -349,10 +350,7 @@ class Sample:
                 )
 
         else:
-            if self.path and get_path_type(self.path) == "local":
-                compressed = self.path
-            else:
-                compressed = self.buffer
+            compressed = self.buffer
 
             if to_pil:
                 self._pil = decompress_array(


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

When a new image is added and it does not fit in a sample compressed chunk, the filename gets lots from the sample_info.

This ensures the filename remains set on the Sample object for later use by the sample_info tensor

### Things to be aware of

We had to remove the logic from sample.py that uses the path as the compressed data if it exists now that we're better setting the path. No tests are failing from the change, so it seems like a needed change to that code

### Things to worry about

Nothing
