### PR TITLE
fixing dtype bug vectorstore

### DIFF
--- a/deeplake/core/vectorstore/test_deeplake_vectorstore.py
+++ b/deeplake/core/vectorstore/test_deeplake_vectorstore.py
@@ -3012,3 +3012,19 @@ def test_delete_all_bug(local_path):
     vs.delete(delete_all=True)
 
     assert len(vs) == 0
+
+
+def test_adding_list_of_numpy_float64_embeddings_should_not_throw_exception(local_path):
+    db = VectorStore(
+        path="mem://xyz",
+    )
+
+    texts, embeddings, ids, metadatas, _ = utils.create_data(
+        number_of_data=10, embedding_dim=3
+    )
+
+    embeddings = [embedding.astype(np.float64) for embedding in embeddings]
+
+    db.add(text=texts, embedding=embeddings, id=ids, metadata=metadatas)
+
+    assert len(db) == 10


### PR DESCRIPTION
## 🚀 🚀 Pull Request
Title: Fix Data Type Mismatch in VectorStore 

Description:

###Summary

This pull request addresses a bug  where creating a tensor using VectorStore and adding it to the tensor embeddings leads to  an error due to a data type mismatch. The issue arises when the default data type is set to float32 while when we add embedding it has dtype float64. VectorStore consistently uses float32 as the default data type and fixing it gives that to change it in the back of VectorStore.

### Fix

 Resolves the error encountered when creating a tensor with VectorStore and adding it to the tensor embedding due to a data type mismatch.

### How to Test
1. Create a tensor using VectorStore.
2. Add embedding to the tensor.
3. Verify that the error no longer occurs.
4. Ensure that other functionalities remain unaffected

### Checklist
 Code has been tested locally and passes all relevant tests.
