### PR TITLE
Revert public token handling until future release

### DIFF
--- a/deeplake/client/client.py
+++ b/deeplake/client/client.py
@@ -28,6 +28,7 @@ from deeplake.client.config import (
     HUB_REST_ENDPOINT,
     HUB_REST_ENDPOINT_LOCAL,
     HUB_REST_ENDPOINT_DEV,
+    GET_TOKEN_SUFFIX,
     HUB_REST_ENDPOINT_STAGING,
     REGISTER_USER_SUFFIX,
     DEFAULT_REQUEST_TIMEOUT,
@@ -187,10 +188,15 @@ class DeepLakeBackendClient:
             LoginException: If there is an issue retrieving the auth token.
 
         """
-        if username != "public":
-            raise LoginException("Can only request a token for the public user")
+        json = {"username": username, "password": password}
+        response = self.request("POST", GET_TOKEN_SUFFIX, json=json)
 
-        return "PUBLIC TOKEN " + ("_" * 150)
+        try:
+            token_dict = response.json()
+            token = token_dict["token"]
+        except Exception:
+            raise LoginException()
+        return token
 
     def send_register_request(self, username: str, email: str, password: str):
         """Sends a request to backend to register a new user.

--- a/deeplake/requirements/tests.txt
+++ b/deeplake/requirements/tests.txt
@@ -1,4 +1,4 @@
-pytest
+pytest==7.4
 pytest-cases
 pytest-benchmark
 pytest-cov


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Revert unreleased changes


### Description

With updates to the auth work, I added an optimization for public token handling which will not work with the current production hub server code.

This PR reverts the code back to what was in main on the last release  

### Things to be aware of

We can bring this change back after teh server-side changes have been made


