### PR TITLE
Preserve lock settings in `get_dataset_with_zero_size_cache`

### DIFF
--- a/deeplake/util/remove_cache.py
+++ b/deeplake/util/remove_cache.py
@@ -44,6 +44,8 @@ def get_dataset_with_zero_size_cache(ds):
         link_creds=ds.link_creds,
         pad_tensors=ds._pad_tensors,
         enabled_tensors=ds.enabled_tensors,
+        lock_timeout=ds._lock_timeout,
+        lock_enabled=ds._locking_enabled,
     )
     if ds.pending_commit_id != commit_id:
         ds.checkout(commit_id)


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

For code that goes through `get_dataset_with_zero_size_cache`, the lock_enabled and lock_timeout arguments are not passed along to the cloned dataset.

This PR fixes it so they are


