### PR TITLE
Added allow_delete flag to dataset

### DIFF
--- a/deeplake/api/tests/test_dataset.py
+++ b/deeplake/api/tests/test_dataset.py
@@ -75,3 +75,23 @@ def test_persistence_bug(local_ds_generator):
 
         ds = local_ds_generator()
         np.testing.assert_array_equal(ds[tensor_name].numpy(), np.array([[1], [2]]))
+
+
+def test_allow_delete(local_ds_generator, local_path):
+    ds = local_ds_generator()
+    assert ds.allow_delete is True
+
+    ds.allow_delete = False
+    assert ds.allow_delete is False
+
+    ds2 = deeplake.load(ds.path)
+    assert ds2.allow_delete is False
+
+    with pytest.raises(DatasetHandlerError):
+        deeplake.empty(ds.path, overwrite=True)
+        deeplake.deepcopy(src=ds.path, dest=local_path, overwrite=True)
+        ds.delete()
+
+    ds.allow_delete = True
+    assert ds.allow_delete is True
+    ds.delete()

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -2598,6 +2598,7 @@ class Dataset:
 
         Raises:
             DatasetTooLargeToDelete: If the dataset is larger than 1 GB and ``large_ok`` is ``False``.
+            DatasetHandlerError: If the dataset is marked as delete_allowed=False.
         """
 
         deeplake_reporter.feature_report(

--- a/deeplake/core/meta/dataset_meta.py
+++ b/deeplake/core/meta/dataset_meta.py
@@ -16,6 +16,7 @@ class DatasetMeta(Meta):
         self.tensor_names = {}
         self.hidden_tensors = []
         self.default_index = Index().to_json()
+        self._allow_delete = True
 
     @property
     def visible_tensors(self):
@@ -33,6 +34,15 @@ class DatasetMeta(Meta):
         # TODO: can optimize this
         return len(self.tobytes())
 
+    @property
+    def allow_delete(self):
+        return self._allow_delete
+
+    @allow_delete.setter
+    def allow_delete(self, value):
+        self._allow_delete = value
+        self.is_dirty = True
+
     def __getstate__(self) -> Dict[str, Any]:
         d = super().__getstate__()
         d["tensors"] = self.tensors.copy()
@@ -40,9 +50,12 @@ class DatasetMeta(Meta):
         d["tensor_names"] = self.tensor_names.copy()
         d["hidden_tensors"] = self.hidden_tensors.copy()
         d["default_index"] = self.default_index.copy()
+        d["allow_delete"] = self._allow_delete
         return d
 
     def __setstate__(self, d):
+        if "allow_delete" in d:
+            d["_allow_delete"] = d.pop("allow_delete")
         self.__dict__.update(d)
 
     def add_tensor(self, name, key, hidden=False):


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

Adds a new `dataset.allow_delete = True|False` property to the dataset object which is stored in the dataset_meta.json file. The purpose of the flag is to allow users to explicitly mark a dataset in a way that keeps others from accidentally deleting it.

The default value is "True", but if it is set to False, any attempt to delete or overwrite the dataset will throw an exception until `dataset.allow_delete=True` is set.

### Things to be aware of

The `large_ok` flag still works as before, where datasets larger than 1GB require that flag to delete. But with allow_delete=False set, small datasets can be protected AND large datasets still cannot be deleted even with large_ok=True.

The `force` flag on deeplake.delete() still allows deletion of directories that don't look like a deeplake dataset. But it does not act as an override to an allow_delete=False setting. 

### Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

### Additional Context

<!--
Add any other context about the problem here.
-->
