### PR TITLE
Ensure username is stored for use in commit messages

### DIFF
--- a/deeplake/api/dataset.py
+++ b/deeplake/api/dataset.py
@@ -1,7 +1,6 @@
 import os
 
 import deeplake
-import jwt
 import pathlib
 import posixpath
 import warnings

--- a/deeplake/client/client.py
+++ b/deeplake/client/client.py
@@ -61,7 +61,6 @@ class DeepLakeBackendClient:
         )
 
         self.version = deeplake.__version__
-        self._token_from_env = False
         self.auth_header = None
         self.token = token or self.get_token()
         self.auth_header = f"Bearer {self.token}"
@@ -73,7 +72,7 @@ class DeepLakeBackendClient:
             remove_token()
             self.token = token or self.get_token()
             self.auth_header = f"Bearer {self.token}"
-        if self._token_from_env:
+        else:
             username = self.get_user_profile()["name"]
             if get_reporting_config().get("username") != username:
                 save_reporting_config(True, username=username)
@@ -81,14 +80,11 @@ class DeepLakeBackendClient:
 
     def get_token(self):
         """Returns a token"""
-        self._token_from_env = False
         token = read_token(from_env=False)
         if token is None:
             token = read_token(from_env=True)
             if token is None:
                 token = self.request_auth_token(username="public", password="")
-            else:
-                self._token_from_env = True
         return token
 
     def request(

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -10,6 +10,8 @@ from functools import partial
 import pathlib
 import numpy as np
 from time import time, sleep
+
+from jwt import DecodeError
 from tqdm import tqdm
 
 import deeplake
@@ -337,8 +339,8 @@ class Dataset:
             return "public"
 
         try:
-            return jwt.decode(self.token, options={"verify_signature": False})["id"]
-        except:
+            return jwt.decode(self.token, options={"verify_signature": False})["id"] # NOSONAR
+        except DecodeError:
             return "public"
 
     @property

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -340,9 +340,7 @@ class Dataset:
             return "public"
 
         try:
-            return jwt.decode(self.token, options={"verify_signature": False})[ # NOSONAR
-                "id"
-            ]
+            return jwt.decode(self.token, options={"verify_signature": False})["id"]
         except DecodeError:
             return "public"
 

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -332,6 +332,17 @@ class Dataset:
                 self.storage.flush()
 
     @property
+    def username(self) -> str:
+        token = self.token()
+        if not token:
+            return "public"
+
+        try:
+            return jwt.decode(token, options={"verify_signature": False})["id"]
+        except:
+            return "public"
+
+    @property
     def num_samples(self) -> int:
         """Returns the length of the smallest tensor.
         Ignores any applied indexing and returns the total length.

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -333,12 +333,11 @@ class Dataset:
 
     @property
     def username(self) -> str:
-        token = self.token()
-        if not token:
+        if not self.token:
             return "public"
 
         try:
-            return jwt.decode(token, options={"verify_signature": False})["id"]
+            return jwt.decode(self.token, options={"verify_signature": False})["id"]
         except:
             return "public"
 

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -340,9 +340,9 @@ class Dataset:
             return "public"
 
         try:
-            return jwt.decode(self.token, options={"verify_signature": False})[
+            return jwt.decode(self.token, options={"verify_signature": False})[ # NOSONAR
                 "id"
-            ]  # NOSONAR
+            ]
         except DecodeError:
             return "public"
 

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -339,7 +339,9 @@ class Dataset:
             return "public"
 
         try:
-            return jwt.decode(self.token, options={"verify_signature": False})["id"] # NOSONAR
+            return jwt.decode(self.token, options={"verify_signature": False})[
+                "id"
+            ]  # NOSONAR
         except DecodeError:
             return "public"
 

--- a/deeplake/core/tests/test_dataset.py
+++ b/deeplake/core/tests/test_dataset.py
@@ -1,0 +1,65 @@
+import os
+
+from deeplake.client.config import DEEPLAKE_AUTH_TOKEN
+from deeplake.core import LRUCache
+from deeplake.core.storage.memory import MemoryProvider
+
+from deeplake.core.dataset import Dataset
+
+
+def test_token_and_username(hub_cloud_dev_token):
+    assert DEEPLAKE_AUTH_TOKEN not in os.environ
+
+    ds = Dataset(
+        storage=LRUCache(
+            cache_storage=MemoryProvider(), cache_size=0, next_storage=MemoryProvider()
+        )
+    )
+    assert ds.token is None
+    assert ds.username == "public"
+
+    # invalid tokens come through as "public"
+    ds = Dataset(
+        token="invalid_value",
+        storage=LRUCache(
+            cache_storage=MemoryProvider(), cache_size=0, next_storage=MemoryProvider()
+        )
+    )
+    assert ds.token == "invalid_value"
+    assert ds.username == "public"
+
+    # valid tokens come through correctly
+    ds = Dataset(
+        token=hub_cloud_dev_token,
+        storage=LRUCache(
+            cache_storage=MemoryProvider(), cache_size=0, next_storage=MemoryProvider()
+        )
+    )
+    assert ds.token == hub_cloud_dev_token
+    assert ds.username == "testingacc2"
+
+    # When env is set, it takes precedence over None for the token but not over a set token
+    try:
+        os.environ[DEEPLAKE_AUTH_TOKEN] = hub_cloud_dev_token
+        ds = Dataset(
+            storage=LRUCache(
+                cache_storage=MemoryProvider(), cache_size=0, next_storage=MemoryProvider()
+            )
+        )
+        assert ds.token == hub_cloud_dev_token
+        assert ds.username == "testingacc2"
+
+        ds = Dataset(
+            token="invalid_value",
+            storage=LRUCache(
+                cache_storage=MemoryProvider(), cache_size=0, next_storage=MemoryProvider()
+            )
+        )
+        assert ds.token == "invalid_value"
+        assert ds.username == "public"
+
+    finally:
+        os.environ.pop(DEEPLAKE_AUTH_TOKEN)
+
+    assert DEEPLAKE_AUTH_TOKEN not in os.environ
+

--- a/deeplake/core/tests/test_dataset.py
+++ b/deeplake/core/tests/test_dataset.py
@@ -23,7 +23,7 @@ def test_token_and_username(hub_cloud_dev_token):
         token="invalid_value",
         storage=LRUCache(
             cache_storage=MemoryProvider(), cache_size=0, next_storage=MemoryProvider()
-        )
+        ),
     )
     assert ds.token == "invalid_value"
     assert ds.username == "public"
@@ -33,7 +33,7 @@ def test_token_and_username(hub_cloud_dev_token):
         token=hub_cloud_dev_token,
         storage=LRUCache(
             cache_storage=MemoryProvider(), cache_size=0, next_storage=MemoryProvider()
-        )
+        ),
     )
     assert ds.token == hub_cloud_dev_token
     assert ds.username == "testingacc2"
@@ -43,7 +43,9 @@ def test_token_and_username(hub_cloud_dev_token):
         os.environ[DEEPLAKE_AUTH_TOKEN] = hub_cloud_dev_token
         ds = Dataset(
             storage=LRUCache(
-                cache_storage=MemoryProvider(), cache_size=0, next_storage=MemoryProvider()
+                cache_storage=MemoryProvider(),
+                cache_size=0,
+                next_storage=MemoryProvider(),
             )
         )
         assert ds.token == hub_cloud_dev_token
@@ -52,8 +54,10 @@ def test_token_and_username(hub_cloud_dev_token):
         ds = Dataset(
             token="invalid_value",
             storage=LRUCache(
-                cache_storage=MemoryProvider(), cache_size=0, next_storage=MemoryProvider()
-            )
+                cache_storage=MemoryProvider(),
+                cache_size=0,
+                next_storage=MemoryProvider(),
+            ),
         )
         assert ds.token == "invalid_value"
         assert ds.username == "public"
@@ -62,4 +66,3 @@ def test_token_and_username(hub_cloud_dev_token):
         os.environ.pop(DEEPLAKE_AUTH_TOKEN)
 
     assert DEEPLAKE_AUTH_TOKEN not in os.environ
-

--- a/deeplake/core/version_control/commit_node.py
+++ b/deeplake/core/version_control/commit_node.py
@@ -33,12 +33,12 @@ class CommitNode:
         node.total_samples_processed = self.total_samples_processed
         return node
 
-    def add_successor(self, node: "CommitNode", message: Optional[str] = None):
+    def add_successor(self, node: "CommitNode", author: str, message: Optional[str] = None):
         """Adds a successor (a type of child) to the node, used for commits."""
         node.parent = self
         self.children.append(node)
         self.commit_message = message
-        self.commit_user_name = get_user_name()
+        self.commit_user_name = author
         self.commit_time = datetime.utcnow()
 
     def merge_from(self, node: "CommitNode"):

--- a/deeplake/core/version_control/commit_node.py
+++ b/deeplake/core/version_control/commit_node.py
@@ -33,7 +33,9 @@ class CommitNode:
         node.total_samples_processed = self.total_samples_processed
         return node
 
-    def add_successor(self, node: "CommitNode", author: str, message: Optional[str] = None):
+    def add_successor(
+        self, node: "CommitNode", author: str, message: Optional[str] = None
+    ):
         """Adds a successor (a type of child) to the node, used for commits."""
         node.parent = self
         self.children.append(node)

--- a/deeplake/util/tests/test_version_control.py
+++ b/deeplake/util/tests/test_version_control.py
@@ -14,10 +14,10 @@ def test_merge_commit_node_map():
     b = CommitNode("main", "b")
     c = CommitNode("main", "c")
     e = CommitNode("main", "e")
-    root.add_successor(a, "commit a")
-    root.add_successor(b, "commit b")
-    a.add_successor(c, "commit c")
-    c.add_successor(e, "commit e")
+    root.add_successor(a, "me", "commit a")
+    root.add_successor(b, "me", "commit b")
+    a.add_successor(c, "me", "commit c")
+    c.add_successor(e, "me", "commit e")
     map1 = {
         FIRST_COMMIT_ID: root,
         "a": a,

--- a/deeplake/util/version_control.py
+++ b/deeplake/util/version_control.py
@@ -175,7 +175,7 @@ def commit(
         hash = generate_hash()
     version_state["commit_id"] = hash
     new_node = CommitNode(version_state["branch"], hash)
-    stored_commit_node.add_successor(new_node, dataset.username(), message)
+    stored_commit_node.add_successor(new_node, dataset.username, message)
     stored_commit_node.is_checkpoint = is_checkpoint
     stored_commit_node.total_samples_processed = total_samples_processed
     version_state["commit_node"] = new_node

--- a/deeplake/util/version_control.py
+++ b/deeplake/util/version_control.py
@@ -175,7 +175,7 @@ def commit(
         hash = generate_hash()
     version_state["commit_id"] = hash
     new_node = CommitNode(version_state["branch"], hash)
-    stored_commit_node.add_successor(new_node, message)
+    stored_commit_node.add_successor(new_node, dataset.username(), message)
     stored_commit_node.is_checkpoint = is_checkpoint
     stored_commit_node.total_samples_processed = total_samples_processed
     version_state["commit_node"] = new_node


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

If a token is passed as `ds = deeplake.empty(..., token = token)` or `ds = deeplake.load(..., token = token)`, the username didn't get stored in a way that would be used by the `ds.commit("message")` and the log would have the user as "public"

### Things to be aware of

The initial commit fixes the issue by storing it in the `reporting_config.json` which is where it's currently read from, although that's not the best solution. 

The problem is that with concurrent use of dataset objects, data is going to be written badly. 

The 2nd commit changes the method signature to take the username to commit as, which can be pulled from the token as needed rather than using the reporting file ever. If we feel like that is too much of a change, we can revert back to the first commit.