### PR TITLE
Removing support for tokens set via the CLI

### DIFF
--- a/deeplake/api/dataset.py
+++ b/deeplake/api/dataset.py
@@ -13,7 +13,6 @@ from deeplake.auto.unstructured.coco.coco import CocoDataset
 from deeplake.auto.unstructured.yolo.yolo import YoloDataset
 from deeplake.client.client import DeepLakeBackendClient
 from deeplake.client.log import logger
-from deeplake.client.utils import get_user_name, read_token
 from deeplake.core.dataset import Dataset, dataset_factory
 from deeplake.core.tensor import Tensor
 from deeplake.core.meta.dataset_meta import DatasetMeta

--- a/deeplake/client/client.py
+++ b/deeplake/client/client.py
@@ -1,3 +1,5 @@
+import os
+
 import deeplake
 import requests  # type: ignore
 import textwrap
@@ -16,9 +18,6 @@ from deeplake.util.exceptions import (
 )
 from deeplake.client.utils import (
     check_response_status,
-    write_token,
-    read_token,
-    remove_token,
     JobResponseStatusSchema,
 )
 from deeplake.client.config import (
@@ -42,6 +41,7 @@ from deeplake.client.config import (
     CONNECT_DATASET_SUFFIX,
     REMOTE_QUERY_SUFFIX,
     ORG_PERMISSION_SUFFIX,
+    DEEPLAKE_AUTH_TOKEN,
 )
 from deeplake.client.log import logger
 import jwt  # should add it to requirements.txt
@@ -63,14 +63,17 @@ class DeepLakeBackendClient:
         self.version = deeplake.__version__
         self._token_from_env = False
         self.auth_header = None
-        self.token = token or self.get_token()
+        self.token = (
+            token
+            or os.environ.get(DEEPLAKE_AUTH_TOKEN)
+            or "PUBLIC_TOKEN_" + ("_" * 150)
+        )
         self.auth_header = f"Bearer {self.token}"
 
         # remove public token, otherwise env var will be ignored
         # we can remove this after a while
         orgs = self.get_user_organizations()
         if orgs == ["public"]:
-            remove_token()
             self.token = token or self.get_token()
             self.auth_header = f"Bearer {self.token}"
         if self._token_from_env:
@@ -80,16 +83,7 @@ class DeepLakeBackendClient:
                 set_username(username)
 
     def get_token(self):
-        """Returns a token"""
-        self._token_from_env = False
-        token = read_token(from_env=False)
-        if token is None:
-            token = read_token(from_env=True)
-            if token is None:
-                token = self.request_auth_token(username="public", password="")
-            else:
-                self._token_from_env = True
-        return token
+        return self.token
 
     def request(
         self,

--- a/deeplake/client/test_client.py
+++ b/deeplake/client/test_client.py
@@ -4,20 +4,6 @@ from deeplake.client.client import (
     DeepMemoryBackendClient,
     JobResponseStatusSchema,
 )
-from deeplake.client.utils import (
-    write_token,
-    read_token,
-    remove_token,
-)
-
-from time import sleep
-
-
-def test_client_utils():
-    write_token("abcdefgh")
-    assert read_token() == "abcdefgh"
-    remove_token()
-    assert read_token() is None
 
 
 def create_response(

--- a/deeplake/client/utils.py
+++ b/deeplake/client/utils.py
@@ -31,33 +31,6 @@ PENDING_STATUS = "not available yet"
 BEST_RECALL = "best_recall@10"
 
 
-def write_token(token: str):
-    """Writes the auth token to the token file."""
-    if not token:
-        raise EmptyTokenException
-    path = Path(TOKEN_FILE_PATH)
-    os.makedirs(path.parent, exist_ok=True)
-    with open(TOKEN_FILE_PATH, "w") as f:
-        f.write(token)
-
-
-def read_token(from_env=True):
-    """Returns the token. Searches for the token first in token file and then in enviroment variables."""
-    token = None
-    if os.path.exists(TOKEN_FILE_PATH):
-        with open(TOKEN_FILE_PATH) as f:
-            token = f.read()
-    elif from_env:
-        token = os.environ.get(DEEPLAKE_AUTH_TOKEN)
-    return token
-
-
-def remove_token():
-    """Deletes the token file"""
-    if os.path.isfile(TOKEN_FILE_PATH):
-        os.remove(TOKEN_FILE_PATH)
-
-
 def remove_username_from_config():
     try:
         config = {}

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -13,6 +13,7 @@ from time import time, sleep
 from tqdm import tqdm
 
 import deeplake
+from deeplake.client.config import DEEPLAKE_AUTH_TOKEN
 from deeplake.core import index_maintenance
 from deeplake.core.index.index import IndexEntry
 from deeplake.core.link_creds import LinkCreds
@@ -36,7 +37,6 @@ from deeplake.util.iteration_warning import (
 from deeplake.util.tensor_db import parse_runtime_parameters
 from deeplake.api.info import load_info
 from deeplake.client.log import logger
-from deeplake.client.utils import read_token
 from deeplake.client.client import DeepLakeBackendClient
 from deeplake.constants import (
     FIRST_COMMIT_ID,
@@ -289,9 +289,9 @@ class Dataset:
             else None
         )
         self._first_load_init()
-        self._initial_autoflush: List[bool] = (
-            []
-        )  # This is a stack to support nested with contexts
+        self._initial_autoflush: List[
+            bool
+        ] = []  # This is a stack to support nested with contexts
         self._indexing_history: List[int] = []
 
         if not self.read_only:
@@ -2680,7 +2680,7 @@ class Dataset:
     @property
     def token(self):
         """Get attached token of the dataset"""
-        return self._token or read_token(from_env=True)
+        return self._token or os.environ.get(DEEPLAKE_AUTH_TOKEN)
 
     @token.setter
     def token(self, new_token: str):

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -289,9 +289,9 @@ class Dataset:
             else None
         )
         self._first_load_init()
-        self._initial_autoflush: List[
-            bool
-        ] = []  # This is a stack to support nested with contexts
+        self._initial_autoflush: List[bool] = (
+            []
+        )  # This is a stack to support nested with contexts
         self._indexing_history: List[int] = []
 
         if not self.read_only:

--- a/deeplake/core/vectorstore/dataset_handlers/dataset_handler_base.py
+++ b/deeplake/core/vectorstore/dataset_handlers/dataset_handler_base.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import pathlib
 from abc import abstractmethod, ABC
 from typing import Optional, Any, List, Dict, Union, Callable
@@ -6,9 +7,9 @@ import jwt
 
 import numpy as np
 
+from deeplake.client.config import DEEPLAKE_AUTH_TOKEN
 from deeplake.util.path import convert_pathlib_to_string_if_needed
 from deeplake.core.dataset import Dataset
-from deeplake.client.utils import read_token
 from deeplake.core.vectorstore import utils
 from deeplake.util.bugout_reporter import (
     feature_report_path,
@@ -99,7 +100,7 @@ class DHBase(ABC):
 
     @property
     def token(self):
-        return self._token or read_token(from_env=True)
+        return self._token or os.environ.get(DEEPLAKE_AUTH_TOKEN)
 
     @property
     def exec_option(self) -> str:

--- a/deeplake/core/vectorstore/vector_search/utils.py
+++ b/deeplake/core/vectorstore/vector_search/utils.py
@@ -9,7 +9,6 @@ import deeplake
 from deeplake.constants import MB, DEFAULT_VECTORSTORE_INDEX_PARAMS, TARGET_BYTE_SIZE
 from deeplake.util.exceptions import TensorDoesNotExistError
 from deeplake.util.warnings import always_warn
-from deeplake.client.utils import read_token
 from deeplake.core.dataset import DeepLakeCloudDataset, Dataset
 from deeplake.core.vectorstore.embeddings.embedder import DeepLakeEmbedder
 from deeplake.client.client import DeepLakeBackendClient

--- a/deeplake/util/bugout_reporter.py
+++ b/deeplake/util/bugout_reporter.py
@@ -6,9 +6,8 @@ from platform import machine
 from typing import Any, Dict, Optional, Union
 import uuid
 
-from deeplake.client.config import REPORTING_CONFIG_FILE_PATH
+from deeplake.client.config import REPORTING_CONFIG_FILE_PATH, DEEPLAKE_AUTH_TOKEN
 from deeplake.client.client import DeepLakeBackendClient
-from deeplake.client.utils import get_user_name, read_token
 from deeplake.util.bugout_token import BUGOUT_TOKEN
 from humbug.consent import HumbugConsent
 from humbug.report import HumbugReporter
@@ -164,7 +163,7 @@ def feature_report_path(
     if path.startswith(starts_with):
         parameters["Path"] = path
 
-    token = token or read_token(from_env=True)
+    token = token or os.environ.get(DEEPLAKE_AUTH_TOKEN)
 
     if token is not None:
         username = jwt.decode(token, options={"verify_signature": False})["id"]


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Description
Now that the CLI has been deprecated there's no way to modify the api tokens saved to `~/.activeloop/token`. We have removed support for providing tokens in this file.
<!--
A clear and concise description of the change being made.  

The title should introduce what was/will be done
  - Titles show in release notes and search results, so make them useful 
  - Be specific about what was fixed or changed
  - Imagine yourself looking for this PR in 6 months -- what will make it findable and valuable to future you?
  - Good Example: `Correctly apply passed S3 credentials when using VectorStore`
  - Bad Example: `Fixed creds issue`  

The description gives the details on what was/will be done 
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need to know and how the fix will affect them
- Describe how the code change addresses the problem
- Imagine yourself looking for this PR in 6 months -- what will make it findable and valuable to future you?
- Ensure private information is redacted.
-->

### Things to be aware of
 Users wanting to set an authorization token will need to employ one of the following methods:

  a) Set the token within the environmental variables.

  b) Pass the token directly to the function being invoked.

User-guided saving of the token within a file is not explicitly supported. It has been left up to developers to modify and manage it based on their specific requirements.

Tokens passed directly to the function will be given preference over tokens set in the env e.g. if you set token A in the env vars and token B is passed to the function; token B will be the token used.
<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

### Things to worry about
If you have explicitly set your token in '~/.activeloop/token' you'll need to use one of the methods above.
<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

### Additional Context

<!--
Add any other context about the problem here.
-->
