### PR TITLE
Fixed allow_delete wording in messages

### DIFF
--- a/deeplake/api/dataset.py
+++ b/deeplake/api/dataset.py
@@ -240,7 +240,7 @@ class dataset:
             if overwrite:
                 if not dataset._allow_delete(cache_chain):
                     raise DatasetHandlerError(
-                        "Dataset overwrite failed. The dataset is marked as delete_allowed=false. To allow overwrite, you must first run `allow_delete(True)` on the dataset."
+                        "Dataset overwrite failed. The dataset is marked as allow_delete=false. To allow overwrite, you must first run `allow_delete = True` on the dataset."
                     )
 
                 try:
@@ -465,7 +465,7 @@ class dataset:
         if overwrite and dataset_exists(cache_chain):
             if not dataset._allow_delete(cache_chain):
                 raise DatasetHandlerError(
-                    "Dataset overwrite failed. The dataset is marked as delete_allowed=false. To allow overwrite, you must first run `allow_delete(True)` on the dataset."
+                    "Dataset overwrite failed. The dataset is marked as allow_delete=false. To allow overwrite, you must first run `allow_delete = True` on the dataset."
                 )
 
             try:
@@ -1289,7 +1289,7 @@ class dataset:
             if overwrite:
                 if not dataset._allow_delete(cache_chain):
                     raise DatasetHandlerError(
-                        "Dataset overwrite failed. The dataset is marked as delete_allowed=false. To allow overwrite, you must first run `allow_delete(True)` on the dataset."
+                        "Dataset overwrite failed. The dataset is marked as allow_delete=false. To allow overwrite, you must first run `allow_delete = True` on the dataset."
                     )
 
                 try:

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -2043,7 +2043,7 @@ class Dataset:
 
     @property
     def allow_delete(self) -> bool:
-        """Returns True if dataset can be deleted from storage. Whether it can be deleted or not is stored in the database_meta.json and can be changed with allow_`delete = True|False`"""
+        """Returns True if dataset can be deleted from storage. Whether it can be deleted or not is stored in the database_meta.json and can be changed with `allow_delete = True|False`"""
         return self.meta.allow_delete
 
     @allow_delete.setter

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -2043,7 +2043,7 @@ class Dataset:
 
     @property
     def allow_delete(self) -> bool:
-        """Returns True if dataset can be deleted from storage. Whether it can be deleted or not is stored in the database_meta.json and can be changed with allow_delete(boolean)"""
+        """Returns True if dataset can be deleted from storage. Whether it can be deleted or not is stored in the database_meta.json and can be changed with allow_`delete = True|False`"""
         return self.meta.allow_delete
 
     @allow_delete.setter
@@ -2598,7 +2598,7 @@ class Dataset:
 
         Raises:
             DatasetTooLargeToDelete: If the dataset is larger than 1 GB and ``large_ok`` is ``False``.
-            DatasetHandlerError: If the dataset is marked as delete_allowed=False.
+            DatasetHandlerError: If the dataset is marked as allow_delete=False.
         """
 
         deeplake_reporter.feature_report(
@@ -2607,7 +2607,7 @@ class Dataset:
 
         if not self.allow_delete:
             raise DatasetHandlerError(
-                "The dataset is marked as delete_allowed=false. To delete this dataset, you must first run `allow_delete(True)` on the dataset."
+                "The dataset is marked as allow_delete=false. To delete this dataset, you must first run `allow_delete = True` on the dataset."
             )
 
         if hasattr(self, "_view_entry"):


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

Some messages accidentally still used the `delete_allowed` and `allow_delete(boolean)` pre-release versions of the new `allow_delete=True|False` API.

This PR fixes the messages to give the correct usage. 

### Things to be aware of

Only updates messages, doesn't change the API

