### PR TITLE
Auto-convert numbers to strings when appending to a text dtype tensor

### DIFF
--- a/deeplake/core/chunk/base_chunk.py
+++ b/deeplake/core/chunk/base_chunk.py
@@ -70,6 +70,7 @@ class BaseChunk(DeepLakeMemoryObject):
         min_chunk_size: int,
         max_chunk_size: int,
         tiling_threshold: int,
+        tensor_meta: TensorMeta,
         compression: Optional[str] = None,
         encoded_shapes: Optional[np.ndarray] = None,
         encoded_byte_positions: Optional[np.ndarray] = None,
@@ -608,11 +609,6 @@ class BaseChunk(DeepLakeMemoryObject):
         if isinstance(sample, numbers.Number):
             sample = str(sample)
 
-        if not isinstance(sample, str):
-            raise ValueError(
-                f"Cannot save data of type '{type(sample).__name__}' in a text tensor"
-            )
-
         try:
             return str(sample.numpy().reshape(())).encode("utf-8")
         except AttributeError:
@@ -623,7 +619,9 @@ class BaseChunk(DeepLakeMemoryObject):
             try:
                 return str(sample.reshape(())).encode("utf-8")
             except AttributeError:  # None
-                return b""
+                raise ValueError(
+                    f"Cannot save data of type '{type(sample).__name__}' in a text tensor"
+                )
 
     def check_empty_before_read(self):
         if self.is_empty_tensor:

--- a/deeplake/core/chunk/base_chunk.py
+++ b/deeplake/core/chunk/base_chunk.py
@@ -619,9 +619,7 @@ class BaseChunk(DeepLakeMemoryObject):
             try:
                 return str(sample.reshape(())).encode("utf-8")
             except AttributeError:  # None
-                raise ValueError(
-                    f"Cannot save data of type '{type(sample).__name__}' in a text tensor"
-                )
+                return b""
 
     def check_empty_before_read(self):
         if self.is_empty_tensor:

--- a/deeplake/core/chunk/base_chunk.py
+++ b/deeplake/core/chunk/base_chunk.py
@@ -1,3 +1,4 @@
+import numbers
 from abc import abstractmethod
 import struct
 import numpy as np
@@ -69,7 +70,6 @@ class BaseChunk(DeepLakeMemoryObject):
         min_chunk_size: int,
         max_chunk_size: int,
         tiling_threshold: int,
-        tensor_meta: TensorMeta,
         compression: Optional[str] = None,
         encoded_shapes: Optional[np.ndarray] = None,
         encoded_byte_positions: Optional[np.ndarray] = None,
@@ -605,6 +605,14 @@ class BaseChunk(DeepLakeMemoryObject):
         )
 
     def _text_sample_to_byte_string(self, sample):
+        if isinstance(sample, numbers.Number):
+            sample = str(sample)
+
+        if not isinstance(sample, str):
+            raise ValueError(
+                f"Cannot save data of type '{type(sample).__name__}' in a text tensor"
+            )
+
         try:
             return str(sample.numpy().reshape(())).encode("utf-8")
         except AttributeError:

--- a/deeplake/core/chunk/tests/test_base_chunk.py
+++ b/deeplake/core/chunk/tests/test_base_chunk.py
@@ -15,7 +15,5 @@ def test_text_sample_to_byte_string():
     assert chunk._text_sample_to_byte_string("test") == b"test"
     assert chunk._text_sample_to_byte_string(3) == b"3"
     assert chunk._text_sample_to_byte_string(3.5) == b"3.5"
-
-    with pytest.raises(ValueError) as e:
-        chunk._text_sample_to_byte_string([1, 2, 3])
-    assert e.match("Cannot save data of type 'list' in a text tensor")
+    assert chunk._text_sample_to_byte_string(None) == b""
+    assert chunk._text_sample_to_byte_string([]) == b""

--- a/deeplake/core/chunk/tests/test_base_chunk.py
+++ b/deeplake/core/chunk/tests/test_base_chunk.py
@@ -1,0 +1,21 @@
+import pytest
+
+from deeplake.core.chunk.uncompressed_chunk import UncompressedChunk
+from deeplake.core.meta import TensorMeta
+
+
+def test_text_sample_to_byte_string():
+    chunk = UncompressedChunk(
+        min_chunk_size=10,
+        max_chunk_size=1000,
+        tiling_threshold=1000,
+        tensor_meta=TensorMeta(),
+    )
+
+    assert chunk._text_sample_to_byte_string("test") == b"test"
+    assert chunk._text_sample_to_byte_string(3) == b"3"
+    assert chunk._text_sample_to_byte_string(3.5) == b"3.5"
+
+    with pytest.raises(ValueError) as e:
+        chunk._text_sample_to_byte_string([1, 2, 3])
+    assert e.match("Cannot save data of type 'list' in a text tensor")


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

A script such as this:

```python
print(ds.str_tensor.numpy())  # prints [['1']]
print(ds.num_tensor.numpy())  # prints [[1]]
print("-----")

ds.append(
    {"str_tensor": 2, "num_tensor": 2}
)  # no error, just first tensor is appended as empty string
print(ds.str_tensor.numpy())  # prints [['1']  ['']]
print(ds.num_tensor.numpy())  # prionts [[1] [2]]
print("-----")

ds.num_tensor.append(3)
ds.str_tensor.append(3)  # same here
print(ds.str_tensor.numpy())  # prints  [['1'] [''] ['']]
print(ds.num_tensor.numpy())  # [[1] [2] [3]]
print("-----")
```

silently appends the numbers in str_tensor as empty strings.

This PR makes numbers automatically convert to strings, and throw an error for all other types. This keeps something more unexpected like `ds.str_tensor.append([1,2,3])` from being auto-converted to a string

