### PR TITLE
Validate htype vs dtype when detecting htype based on inserted data

### DIFF
--- a/deeplake/api/tests/test_api.py
+++ b/deeplake/api/tests/test_api.py
@@ -1679,6 +1679,14 @@ def test_auto_htype(memory_ds):
     assert ds.f.htype == "json"
 
 
+def test_datatype_conversions(memory_ds):
+    ds = memory_ds
+    ds.create_tensor("uuid", dtype=np.int32)
+
+    with pytest.raises(SampleAppendError) as e:
+        ds.uuid.append("asdasd")
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "args", [{}, {"sample_compression": "lz4"}, {"chunk_compression": "lz4"}]

--- a/deeplake/core/tests/test_dataset.py
+++ b/deeplake/core/tests/test_dataset.py
@@ -1,10 +1,19 @@
 import os
+import traceback
 
+import numpy as np
+import pytest
+
+import deeplake
 from deeplake.client.config import DEEPLAKE_AUTH_TOKEN
 from deeplake.core import LRUCache
 from deeplake.core.storage.memory import MemoryProvider
 
 from deeplake.core.dataset import Dataset
+from deeplake.util.exceptions import (
+    TensorMetaInvalidHtypeOverwriteValue,
+    SampleAppendError,
+)
 
 
 def test_token_and_username(hub_cloud_dev_token):


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

When running a script like:
```
ds = deeplake.empty('mem://dummy')

ds.create_tensor('uuid', dtype = np.int32)
ds.uuid.append('asdasd')
ds.uuid.append(1)
```
The htype gets set as "text" even though that isn't compatible with the specified dtype of "int32"

This PR adds validation to the htype computation to ensure it matches the specified dtype

