### PR TITLE
Generate a better error message if a list or other unsupported argument is passed to video.normalize_index

### DIFF
--- a/deeplake/util/tests/test_video.py
+++ b/deeplake/util/tests/test_video.py
@@ -1,0 +1,14 @@
+from deeplake.util.video import normalize_index
+import pytest
+
+
+def test_normalize_index():
+    assert normalize_index(None, 10) == (0, 10, 1, False)
+    assert normalize_index(5, 10) == (5, 6, 1, False)
+    assert normalize_index(slice(5, 10, 2), 10) == (5, 10, 2, False)
+    assert normalize_index(slice(5, 10, 2), 10) == (5, 10, 2, False)
+    assert normalize_index(slice(5, None, 2), 10) == (5, 10, 2, False)
+    assert normalize_index(slice(None, 5, 2), 10) == (0, 5, 2, False)
+
+    with pytest.raises(IndexError):
+        normalize_index([5, 7, 8], 10)

--- a/deeplake/util/video.py
+++ b/deeplake/util/video.py
@@ -33,5 +33,13 @@ def normalize_index(index, nframes):
 
         if reverse:
             start, stop = stop + 1, start + 1
+    elif isinstance(index, list):
+        raise IndexError(
+            f"Cannot specify a list video frames. You must specify a range with an optional step such as [5:10] or [0:100:5]"
+        )
+    else:
+        raise IndexError(
+            f"Invalid video index type: {type(index)}. You must specify either a specific frame index or a range."
+        )
 
     return start, stop, step, reverse


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

The video frame lookup does not support lists or other object types, so `ds.video[0][[0,1,2],].numpy().shape` throws an unhelpful error message.

This PR provides a better error message for `lists` in particular and any unsupported type in general. 

### Things to be aware of

Only impacts video parsing

