### PR TITLE
(old) Fixed tensor "sample_info" on some saved view samples

### DIFF
--- a/deeplake/core/chunk/sample_compressed_chunk.py
+++ b/deeplake/core/chunk/sample_compressed_chunk.py
@@ -33,6 +33,21 @@ class SampleCompressedChunk(BaseChunk):
                     continue
                 raise
 
+            if serialized_sample:
+                path = None
+                if isinstance(incoming_sample, Sample):
+                    path = incoming_sample.path
+
+                sample = Sample(
+                    buffer=serialized_sample,
+                    compression=compr,
+                    shape=shape,
+                    dtype=dtype,
+                    path=path,  # type: ignore
+                )
+                sample.htype = self.htype
+                incoming_samples[i] = sample
+
             if isinstance(serialized_sample, SampleTiles):
                 incoming_samples[i] = serialized_sample  # type: ignore
                 if self.is_empty:
@@ -52,20 +67,6 @@ class SampleCompressedChunk(BaseChunk):
                     )
                     num_samples += 1
                 else:
-                    if serialized_sample:
-                        path = None
-                        if isinstance(incoming_sample, Sample):
-                            path = incoming_sample.path
-
-                        sample = Sample(
-                            buffer=serialized_sample,
-                            compression=compr,
-                            shape=shape,
-                            dtype=dtype,
-                            path=path,  # type: ignore
-                        )
-                        sample.htype = self.htype
-                        incoming_samples[i] = sample
                     break
 
         for i in reversed(skipped):

--- a/deeplake/core/sample.py
+++ b/deeplake/core/sample.py
@@ -150,6 +150,9 @@ class Sample:
             return self._buffer
         return self.compressed_bytes(self.compression)
 
+    def __len__(self):
+        return self.shape[0]
+
     @property
     def is_text_like(self):
         return self.htype in {"text", "list", "json", "tag"}


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

When saving a view, the `sample_info` on some tensors are not correctly saved to the view.

Example:
```
ds = deeplake.load(
    "hub://example/my-dataset",
    read_only=True,
    token=token,
)

view = ds[0:3]
print(view.t1[0].sample_info) # Will print valid sample_info

view.save_view(message='First 3 samples materialized', optimize = True)

view_loaded = ds.load_view(id = ds.get_views()[-1].id)
print(view_loaded.t1[0].sample_info) # Will print empty dict
``` 

### Things to be aware of

Changes the code that generally replaces Tensors with Samples in the sample list that flows through the write process. The problem was that when it came to writing the sample_info hidden tensor, any samples that fit in the chunk originally were not being converted to Samples and the sample_info writer has no metadata to write.

This ensures the Sample object is created for that code, and anywhere else that expects it to be a Sample

### Things to worry about

Is there any code or functionality that expected/required it to remain a Tensor in these cases?
