### PR TITLE
Fixed tensor "sample_info" on some saved view samples

### DIFF
--- a/deeplake/core/tensor_link.py
+++ b/deeplake/core/tensor_link.py
@@ -83,6 +83,8 @@ def extend_info(samples, link_creds=None, progressbar=False):
                 sample = sample.copy()
             meta = sample.meta
             meta["modified"] = False
+        if isinstance(sample, deeplake.Tensor):
+            meta = sample.sample_info
         metas.append(meta)
     return metas
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

When saving a view, the `sample_info` on some tensors are not correctly saved to the view.

Example:
```
ds = deeplake.load(
    "hub://example/my-dataset",
    read_only=True,
    token=token,
)

view = ds[0:3]
print(view.t1[0].sample_info) # Will print valid sample_info

view.save_view(message='First 3 samples materialized', optimize = True)

view_loaded = ds.load_view(id = ds.get_views()[-1].id)
print(view_loaded.t1[0].sample_info) # Will print empty dict
``` 

### Things to be aware of

This is a more isolated fix than #2791 which updates one place to also know how to deal with Tensor objects rather than just Sample objects. The more isolated fix won't fix any similar problems that live elsewhere, but also doesn't break other code paths like 2791 was.
