### PR TITLE
Don't require azure modules to be installed

### DIFF
--- a/deeplake/client/auth/azure.py
+++ b/deeplake/client/auth/azure.py
@@ -1,7 +1,5 @@
 import os
 from datetime import datetime, timedelta
-from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
-from azure.core.exceptions import ClientAuthenticationError
 
 from deeplake.client.auth.auth_context import AuthContext, AuthProviderType
 from deeplake.util.exceptions import InvalidAuthContextError
@@ -11,6 +9,14 @@ ID_TOKEN_CACHE_MINUTES = 5
 
 class AzureAuthContext(AuthContext):
     def __init__(self):
+        try:
+            from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+            from azure.core.exceptions import ClientAuthenticationError
+        except ImportError:
+            raise ImportError(
+                "Azure packages not installed. Run `pip install deeplake[azure]`."
+            )
+
         self.credential = self._get_azure_credential()
         self.token = None
         self._last_auth_time = None

--- a/deeplake/client/auth/azure.py
+++ b/deeplake/client/auth/azure.py
@@ -22,6 +22,8 @@ class AzureAuthContext(AuthContext):
         self._last_auth_time = None
 
     def _get_azure_credential(self):
+        from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+
         azure_keys = [i for i in os.environ if i.startswith("AZURE_")]
         if "AZURE_CLIENT_ID" in azure_keys and len(azure_keys) == 1:
             # Explicitly set client_id, to avoid any warnings coming from DefaultAzureCredential
@@ -43,6 +45,8 @@ class AzureAuthContext(AuthContext):
             < timedelta(minutes=ID_TOKEN_CACHE_MINUTES)
         ):
             return
+
+        from azure.core.exceptions import ClientAuthenticationError
 
         try:
             response = self.credential.get_token(


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

3.8.26 incorrectly assumed azure is installed. It is only available with `pip install deeplake[azure]`

This PR makes the import only happen on functionality use

