### PR TITLE
Avoid making http requests to validate unauthenticated users

### DIFF
--- a/deeplake/client/auth/activeloop.py
+++ b/deeplake/client/auth/activeloop.py
@@ -15,6 +15,9 @@ class ActiveLoopAuthContext(AuthContext):
 
         return self.token
 
+    def is_public_user(self) -> bool:
+        return self.get_token().startswith("PUBLIC_TOKEN_")
+
     def authenticate(self) -> None:
         self.token = (
             self.token

--- a/deeplake/client/auth/auth_context.py
+++ b/deeplake/client/auth/auth_context.py
@@ -19,6 +19,11 @@ class AuthContext(ABC):
     def get_token(self) -> Optional[str]:
         pass
 
+    # Return True if the user has no authentication token
+    @abstractmethod
+    def is_public_user(self) -> bool:
+        pass
+
     @abstractmethod
     def authenticate(self) -> None:
         """

--- a/deeplake/client/auth/azure.py
+++ b/deeplake/client/auth/azure.py
@@ -33,6 +33,9 @@ class AzureAuthContext(AuthContext):
 
         return DefaultAzureCredential()
 
+    def is_public_user(self) -> bool:
+        return False
+
     def get_token(self) -> str:
         self.authenticate()
 

--- a/deeplake/client/client.py
+++ b/deeplake/client/client.py
@@ -349,6 +349,9 @@ class DeepLakeBackendClient:
         Returns:
             list: user/organization names
         """
+        if self.auth_context.is_public_user():
+            return ["public"]
+
         response = self.request(
             "GET", GET_USER_PROFILE, endpoint=self.endpoint()
         ).json()


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

If a user has no token, there is no need to make the API call to /api/user/profile. We can just know their organization is "public" without making the call.

### Things to be aware of

`get_user_organizations()` is the only use of `/api/user/profile`

