### PR TITLE
Check function passed to dataset.filter() is correctly configured

### DIFF
--- a/deeplake/core/query/filter.py
+++ b/deeplake/core/query/filter.py
@@ -79,7 +79,7 @@ def filter_dataset(
     ):
         # Looks like user did not call the @deeplake.compute decorated function before passing it to filter
         # because the signature matches the "inner" function in deeplake/core/transform/transform.py
-        filter_function = filter_function()
+        filter_function = filter_function()  # type: ignore
 
     tm = time()
 

--- a/deeplake/core/query/filter.py
+++ b/deeplake/core/query/filter.py
@@ -71,6 +71,16 @@ def filter_dataset(
 ) -> deeplake.Dataset:
     index_map: List[int]
 
+    if (
+        hasattr(filter_function, "__name__")
+        and filter_function.__name__ == "inner"
+        and list(inspect.signature(filter_function).parameters.keys())
+        == ["args", "kwargs"]
+    ):
+        # Looks like user did not call the @deeplake.compute decorated function before passing it to filter
+        # because the signature matches the "inner" function in deeplake/core/transform/transform.py
+        filter_function = filter_function()
+
     tm = time()
 
     query_text = _filter_function_to_query_text(filter_function)

--- a/deeplake/core/transform/transform.py
+++ b/deeplake/core/transform/transform.py
@@ -640,6 +640,7 @@ def compute(
     - ``TransformError``: All other exceptions raised if there are problems while running the pipeline.
     """
 
+    # Note: the name and signature of this method is checked for in deeplake/core/query/filter.py:filter_dataset()
     def inner(*args, **kwargs):
         return ComputeFunction(fn, args, kwargs, name)
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

When defining a filter like this:
```
@deeplake.compute
def filter_fn(sample):
    return sample.t1.data()["value"] == "Hello"

view = ds.filter(filter_fn())
```

if you forget the `()`in `view = ds.filter(filter_fn())` your data is not filtered. 

This PR looks for that pattern and auto-calls the function for you.

### Things to be aware of

It is still valid to call:
```
def filter_fn(sample):
    return sample.t1.data()["value"] == "Hello"

view = ds.filter(filter_fn)
```
which doesn't annotate filter_fn and therefore should NOT have `()` on the value passed to ds.filter()


### Additional Context

<!--
Add any other context about the problem here.
-->
