### PR TITLE
Added "allow_new_labels" flag for class_labels tensor

### DIFF
--- a/deeplake/core/chunk_engine.py
+++ b/deeplake/core/chunk_engine.py
@@ -789,6 +789,13 @@ class ChunkEngine:
         class_names = tensor_info.class_names
         labels, additions = convert_to_idx(samples, class_names)
         if additions:
+            if (
+                "allow_new_labels" in tensor_info
+                and tensor_info["allow_new_labels"] is False
+            ):
+                raise ValueError(
+                    f"New label(s) [{','.join([i[0] for i in additions])}] are not allowed for tensor {tensor_name}. Allowed labels are: [{','.join(tensor_info.class_names)}]"
+                )
             for new in additions:
                 class_names.append(new[0])
                 logger.info(

--- a/deeplake/htype.py
+++ b/deeplake/htype.py
@@ -64,7 +64,11 @@ HTYPE_CONFIGURATIONS: Dict[str, Dict] = {
     htype.CLASS_LABEL: {
         "dtype": "uint32",
         "class_names": [],
-        "_info": ["class_names"],  # class_names should be stored in info, not meta
+        "allow_new_labels": True,
+        "_info": [
+            "class_names",
+            "allow_new_labels",
+        ],  # class_names should be stored in info, not meta
         "_disable_temp_transform": False,
     },
     htype.BBOX: {"dtype": "float32", "coords": {}, "_info": ["coords"]},


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

By default, tensors with htype="class_label" will accept any new values added to them. This PR adds a new `allow_new_labels=False` setting in the tensor "info" which changes that behavior to instead throw an exception if an unknown label is added. 

The available labels are set in the `info["class_names"]` setting, either when the tensor is originally created:
```
        ds.create_tensor(
            "labels",
            htype="class_label",
            class_names=["cat", "dog", "horse"],
            allow_new_labels=False,
        )
```   

or set/updated later:
```
ds.labels.info.update(allow_new_labels=False)
ds.labels.info.update(class_names=["cat", "dog", "horse")
```

### Things to be aware of

If you update the class_names to be a different order or skipping existing labels, the label_id->text mapping will be off and reading from the tensor will give you incorrect results.
