### PR TITLE
Proactively remove LRU cache values as cache fills

### DIFF
--- a/deeplake/core/chunk_engine.py
+++ b/deeplake/core/chunk_engine.py
@@ -2157,7 +2157,7 @@ class ChunkEngine:
             return None, chunk_info
         cache_used_percent = lambda: self.cache.cache_used / self.cache.cache_size
         while cache_used_percent() > 0.9:
-            time.sleep(0.1)
+            self.cache._pop_from_cache()
         base_storage = storages.get(threading.get_ident())
         if base_storage is None:
             if isinstance(self.base_storage, MemoryProvider):

--- a/deeplake/core/index/index.py
+++ b/deeplake/core/index/index.py
@@ -200,8 +200,6 @@ class IndexEntry:
     def subscriptable(self):
         """Returns whether an IndexEntry can be further subscripted."""
 
-        from deeplake.enterprise.util import INDRA_INSTALLED
-
         if "indra" in sys.modules:
             from indra import api  # type: ignore
 

--- a/deeplake/core/index/index.py
+++ b/deeplake/core/index/index.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Union, List, Tuple, Iterable, Optional
 from collections.abc import Iterable
 import numpy as np
@@ -201,7 +202,7 @@ class IndexEntry:
 
         from deeplake.enterprise.util import INDRA_INSTALLED
 
-        if INDRA_INSTALLED:
+        if "indra" in sys.modules:
             from indra import api  # type: ignore
 
             if isinstance(self.value, api.core.IndexMappingInt64):


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

When loading chunk files from disk, as memory fills the chunk_engine would wait for there to be room to download. Depending on the overall workload, this waiting could last forever.

This change pops a cached value rather than simply wait

