### PR TITLE
Improve file type detection using headers and ignoring URL arguments

### DIFF
--- a/deeplake/api/dataset.py
+++ b/deeplake/api/dataset.py
@@ -11,6 +11,7 @@ from deeplake.auto.unstructured.kaggle import download_kaggle_dataset
 from deeplake.auto.unstructured.image_classification import ImageClassification
 from deeplake.auto.unstructured.coco.coco import CocoDataset
 from deeplake.auto.unstructured.yolo.yolo import YoloDataset
+from deeplake.client.client import DeepLakeBackendClient
 from deeplake.client.log import logger
 from deeplake.core.dataset import Dataset, dataset_factory
 from deeplake.core.dataset.indra_dataset_view import IndraDatasetView
@@ -447,6 +448,16 @@ class dataset:
 
         if creds is None:
             creds = {}
+
+        if "creds_key" in creds:
+            client = DeepLakeBackendClient(token)
+            creds_key = creds["creds_key"]
+
+            if "org_id" not in creds:
+                raise ValueError("org_id is required when using creds_key")
+            org_id = creds["org_id"]
+
+            creds = client.get_managed_creds(org_id, creds_key)
 
         try:
             storage, cache_chain = get_storage_and_cache_chain(

--- a/deeplake/api/dataset.py
+++ b/deeplake/api/dataset.py
@@ -11,7 +11,6 @@ from deeplake.auto.unstructured.kaggle import download_kaggle_dataset
 from deeplake.auto.unstructured.image_classification import ImageClassification
 from deeplake.auto.unstructured.coco.coco import CocoDataset
 from deeplake.auto.unstructured.yolo.yolo import YoloDataset
-from deeplake.client.client import DeepLakeBackendClient
 from deeplake.client.log import logger
 from deeplake.core.dataset import Dataset, dataset_factory
 from deeplake.core.dataset.indra_dataset_view import IndraDatasetView
@@ -449,16 +448,6 @@ class dataset:
         if creds is None:
             creds = {}
 
-        if "creds_key" in creds:
-            client = DeepLakeBackendClient(token)
-            creds_key = creds["creds_key"]
-
-            if "org_id" not in creds:
-                raise ValueError("org_id is required when using creds_key")
-            org_id = creds["org_id"]
-
-            creds = client.get_managed_creds(org_id, creds_key)
-
         try:
             storage, cache_chain = get_storage_and_cache_chain(
                 path=path,
@@ -822,7 +811,7 @@ class dataset:
         """Renames dataset at ``old_path`` to ``new_path``.
 
         Examples:
-            >>> deeplake.rename("hub://username/image_ds", "new_ds")
+
             >>> deeplake.rename("hub://username/image_ds", "hub://username/new_ds")
             >>> deeplake.rename("s3://mybucket/my_ds", "s3://mybucket/renamed_ds")
 

--- a/deeplake/api/dataset.py
+++ b/deeplake/api/dataset.py
@@ -811,7 +811,7 @@ class dataset:
         """Renames dataset at ``old_path`` to ``new_path``.
 
         Examples:
-
+            >>> deeplake.rename("hub://username/image_ds", "new_ds")
             >>> deeplake.rename("hub://username/image_ds", "hub://username/new_ds")
             >>> deeplake.rename("s3://mybucket/my_ds", "s3://mybucket/renamed_ds")
 

--- a/deeplake/core/compression.py
+++ b/deeplake/core/compression.py
@@ -497,8 +497,8 @@ def get_compression(header=None, path=None):
                 return fmt[1:]
     if header:
         if (
-            header[4:12] == b'\x66\x74\x79\x70\x4D\x53\x4E\x56'
-            or header[4:12] == b'\x66\x74\x79\x70\x69\x73\x6F\x6D'
+            header[4:12] == b"\x66\x74\x79\x70\x4D\x53\x4E\x56"
+            or header[4:12] == b"\x66\x74\x79\x70\x69\x73\x6F\x6D"
         ):
             return "mp4"
         if header[0:4] == b"\x1A\x45\xDF\xA3":

--- a/deeplake/core/sample.py
+++ b/deeplake/core/sample.py
@@ -9,7 +9,7 @@ from deeplake.core.compression import (
     _read_metadata_from_vstream,
     _read_audio_meta,
     _read_3d_data_meta,
-    _open_nifti,
+    _open_nifti, HEADER_MAX_BYTES,
 )
 from deeplake.compression import (
     get_compression_type,
@@ -104,7 +104,7 @@ class Sample:
                     self._compression = get_compression(path=self.path)
                 compressed_bytes = self._read_from_path()
                 if self._compression is None:
-                    self._compression = get_compression(header=compressed_bytes[:32])
+                    self._compression = get_compression(header=compressed_bytes[:HEADER_MAX_BYTES])
                 self._shape, self._typestr = verify_compressed_file(compressed_bytes, self._compression)  # type: ignore
 
         if array is not None:
@@ -318,7 +318,7 @@ class Sample:
                     self._compression = get_compression(path=self.path)
                 compressed_bytes = self._read_from_path()
                 if self._compression is None:
-                    self._compression = get_compression(header=compressed_bytes[:32])
+                    self._compression = get_compression(header=compressed_bytes[:HEADER_MAX_BYTES])
                 if self._compression == compression:
                     if self._shape is None:
                         _, self._shape, self._typestr = read_meta_from_compressed_file(
@@ -328,7 +328,7 @@ class Sample:
                     compressed_bytes = self._recompress(compressed_bytes, compression)
             elif self._buffer is not None:
                 if self._compression is None:
-                    self._compression = get_compression(header=self._buffer[:32])
+                    self._compression = get_compression(header=self._buffer[:HEADER_MAX_BYTES])
                 if self._compression == compression:
                     compressed_bytes = self._buffer
                 else:

--- a/deeplake/core/sample.py
+++ b/deeplake/core/sample.py
@@ -9,7 +9,8 @@ from deeplake.core.compression import (
     _read_metadata_from_vstream,
     _read_audio_meta,
     _read_3d_data_meta,
-    _open_nifti, HEADER_MAX_BYTES,
+    _open_nifti,
+    HEADER_MAX_BYTES,
 )
 from deeplake.compression import (
     get_compression_type,
@@ -104,7 +105,9 @@ class Sample:
                     self._compression = get_compression(path=self.path)
                 compressed_bytes = self._read_from_path()
                 if self._compression is None:
-                    self._compression = get_compression(header=compressed_bytes[:HEADER_MAX_BYTES])
+                    self._compression = get_compression(
+                        header=compressed_bytes[:HEADER_MAX_BYTES]
+                    )
                 self._shape, self._typestr = verify_compressed_file(compressed_bytes, self._compression)  # type: ignore
 
         if array is not None:
@@ -318,7 +321,9 @@ class Sample:
                     self._compression = get_compression(path=self.path)
                 compressed_bytes = self._read_from_path()
                 if self._compression is None:
-                    self._compression = get_compression(header=compressed_bytes[:HEADER_MAX_BYTES])
+                    self._compression = get_compression(
+                        header=compressed_bytes[:HEADER_MAX_BYTES]
+                    )
                 if self._compression == compression:
                     if self._shape is None:
                         _, self._shape, self._typestr = read_meta_from_compressed_file(
@@ -328,7 +333,9 @@ class Sample:
                     compressed_bytes = self._recompress(compressed_bytes, compression)
             elif self._buffer is not None:
                 if self._compression is None:
-                    self._compression = get_compression(header=self._buffer[:HEADER_MAX_BYTES])
+                    self._compression = get_compression(
+                        header=self._buffer[:HEADER_MAX_BYTES]
+                    )
                 if self._compression == compression:
                     compressed_bytes = self._buffer
                 else:


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description
Previously, we just looked at the end of the file string to determine the filetype in a `ds.tensor_name.append(deeplake.read(...))` call.

For data read from URLs with query parameters, the end of the path was not necessarily the extension. Also, with URLs in general the path does not necessarily include the extension.

This PR removes any query parameters from the path when checking for a recognized extension, and also checks more header data to detect filetypes than the images we did previously.

### Things to be aware of

Not all types can be detected by headers, but most are now


