### PR TITLE
Store sample_info for segment_mask htypes

### DIFF
--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -908,6 +908,7 @@ class Dataset:
             "point_cloud",
             "mesh",
             "nifti",
+            "segment_mask",
         ):
             self._create_sample_info_tensor(name)
         if create_shape_tensor and htype not in ("text", "json", "tag"):


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

Previously, sample_info was only stored for the following htypes:
- image
- audio
- video
- dicom
- point_cloud
- mesh
- nifti

This PR adds "segment_mask" to that list

### Things to be aware of

Will not create the sample_info for existing segment_mask tensors. If you need sample_info for a segment_mask you will need to create a new tensor and copy the data over

