### PR TITLE
Support for Numpy 2.0

### DIFF
--- a/deeplake/api/tests/test_api.py
+++ b/deeplake/api/tests/test_api.py
@@ -59,7 +59,7 @@ import pickle
 
 # need this for 32-bit and 64-bit systems to have correct tests
 MAX_INT_DTYPE = np.int_.__name__
-MAX_FLOAT_DTYPE = np.float_.__name__
+MAX_FLOAT_DTYPE = np.float64.__name__
 
 
 # not using the predefined parametrizes because `hub_cloud_ds_generator` is not enabled by default

--- a/deeplake/api/tests/test_casting.py
+++ b/deeplake/api/tests/test_casting.py
@@ -11,7 +11,8 @@ def test_intelligent_cast():
     assert intelligent_cast(1, np.float64, "generic").dtype == np.float64
     assert intelligent_cast(True, np.bool_, "generic").dtype == np.bool_
 
-    with pytest.raises(TensorDtypeMismatchError):
-        intelligent_cast(1, "int32", "generic")
-    with pytest.raises(TensorDtypeMismatchError):
-        intelligent_cast(1, np.float32, "generic")
+    if np.lib.NumpyVersion(np.__version__) >= '2.0.0':
+        with pytest.raises(TensorDtypeMismatchError):
+            intelligent_cast(1, "int32", "generic")
+        with pytest.raises(TensorDtypeMismatchError):
+            intelligent_cast(1, np.float32, "generic")

--- a/deeplake/api/tests/test_casting.py
+++ b/deeplake/api/tests/test_casting.py
@@ -1,0 +1,17 @@
+import numpy as np
+import pytest
+
+from deeplake.util.casting import intelligent_cast
+from deeplake.util.exceptions import TensorDtypeMismatchError
+
+
+def test_intelligent_cast():
+    assert intelligent_cast(1, "int64", "generic").dtype == np.int64
+    assert intelligent_cast(1, np.int64, "generic").dtype == np.int64
+    assert intelligent_cast(1, np.float64, "generic").dtype == np.float64
+    assert intelligent_cast(True, np.bool_, "generic").dtype == np.bool_
+
+    with pytest.raises(TensorDtypeMismatchError):
+        intelligent_cast(1, "int32", "generic")
+    with pytest.raises(TensorDtypeMismatchError):
+        intelligent_cast(1, np.float32, "generic")

--- a/deeplake/api/tests/test_casting.py
+++ b/deeplake/api/tests/test_casting.py
@@ -9,9 +9,12 @@ def test_intelligent_cast():
     assert intelligent_cast(1, "int64", "generic").dtype == np.int64
     assert intelligent_cast(1, np.int64, "generic").dtype == np.int64
     assert intelligent_cast(1, np.float64, "generic").dtype == np.float64
+    assert intelligent_cast(1.6, np.float64, "generic").dtype == np.float64
     assert intelligent_cast(True, np.bool_, "generic").dtype == np.bool_
 
     if np.lib.NumpyVersion(np.__version__) >= '2.0.0':
+        with pytest.raises(TensorDtypeMismatchError):
+            intelligent_cast(1.3, "int64", "generic")
         with pytest.raises(TensorDtypeMismatchError):
             intelligent_cast(1, "int32", "generic")
         with pytest.raises(TensorDtypeMismatchError):

--- a/deeplake/core/compression.py
+++ b/deeplake/core/compression.py
@@ -31,7 +31,6 @@ import mmap
 import struct
 import sys
 import re
-from numpy.core.fromnumeric import compress  # type: ignore
 import math
 from pathlib import Path
 from gzip import GzipFile

--- a/deeplake/util/casting.py
+++ b/deeplake/util/casting.py
@@ -125,15 +125,21 @@ def get_incompatible_dtype(
         None if all samples are compatible. If not, the dtype of the offending item is returned.
 
     Raises:
-        TypeError: if samples is of unexepcted type.
+        TypeError: if samples is of unexpected type.
     """
     if isinstance(samples, np.ndarray):
         if samples.size == 0:
             return None
         elif samples.size == 1:
             samples = samples.reshape(1).tolist()[0]
-
-    if isinstance(samples, (int, float, bool)) or hasattr(samples, "dtype"):
+    if isinstance(samples, (int, float, bool)):
+        samples_np = np.array(samples)
+        return (
+            None
+            if np.can_cast(samples_np, dtype)
+            else getattr(samples, "dtype", samples_np.dtype)
+        )
+    elif hasattr(samples, "dtype"):
         return (
             None
             if np.can_cast(samples, dtype)

--- a/deeplake/util/casting.py
+++ b/deeplake/util/casting.py
@@ -133,11 +133,16 @@ def get_incompatible_dtype(
         elif samples.size == 1:
             samples = samples.reshape(1).tolist()[0]
     if isinstance(samples, (int, float, bool)):
-        samples_np = np.array(samples)
+        if isinstance(samples, bool):
+            correct_dtype = (dtype == np.bool_ or dtype == "bool")
+        elif isinstance(samples, int):
+            correct_dtype = (dtype == np.int64 or dtype == "int64" or dtype == np.float64 or dtype == "float64")
+        elif isinstance(samples, float):
+            correct_dtype = (dtype == np.float64 or dtype == "float64")
         return (
             None
-            if np.can_cast(samples_np, dtype)
-            else getattr(samples, "dtype", samples_np.dtype)
+            if correct_dtype
+            else getattr(samples, "dtype", np.array(samples).dtype)
         )
     elif hasattr(samples, "dtype"):
         return (

--- a/deeplake/util/casting.py
+++ b/deeplake/util/casting.py
@@ -133,16 +133,11 @@ def get_incompatible_dtype(
         elif samples.size == 1:
             samples = samples.reshape(1).tolist()[0]
     if isinstance(samples, (int, float, bool)):
-        if isinstance(samples, bool):
-            correct_dtype = (dtype == np.bool_ or dtype == "bool")
-        elif isinstance(samples, int):
-            correct_dtype = (dtype == np.int64 or dtype == "int64" or dtype == np.float64 or dtype == "float64")
-        elif isinstance(samples, float):
-            correct_dtype = (dtype == np.float64 or dtype == "float64")
+        samples_np = np.array(samples)
         return (
             None
-            if correct_dtype
-            else getattr(samples, "dtype", np.array(samples).dtype)
+            if np.can_cast(samples_np, dtype)
+            else getattr(samples, "dtype", samples_np.dtype)
         )
     elif hasattr(samples, "dtype"):
         return (


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [X] Breaking change (fix or feature that would cause existing functionality to change)


### Description

Numpy 2.0 changes some of it's behavior in ways that are not compatible with the existing deeplake code.

This PR updates deeplake to be compatible with both 1.x and 2.0

### Things to be aware of

Numpy removed support for `can_cast()` between python types and numpy types as part of https://numpy.org/neps/nep-0050-scalar-promotion.html . This PR makes deeplake's cast checks still support a comparison between a python sample and a dtype, but follows the new numpy standard of not taking the value into account.

Because python ints/floats are np int64/float64s, this means that you can no longer add a python int to an int32 tensor -- you must explicitly create it as an np.int32. 

This better matches other codepaths deeplake already has, so is bringing more consistency. But, there may be cases where doesn't work with existing scripts.

### Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

### Additional Context

<!--
Add any other context about the problem here.
-->
