### PR TITLE
Handle creating a view of a tensor group

### DIFF
--- a/deeplake/api/dataset.py
+++ b/deeplake/api/dataset.py
@@ -1151,7 +1151,8 @@ class dataset:
                 destination_ds.delete_tensor(tensor_name)
             destination_ds.create_tensor_like(tensor_name, source_tensor, unlink=tensor_name in unlink)  # type: ignore
 
-        destination_ds.info.update(source_ds.info.__getstate__())  # type: ignore
+        if not source_ds.group_index:
+            destination_ds.info.update(source_ds.info.__getstate__())  # type: ignore
 
         return destination_ds
 

--- a/deeplake/core/index_maintenance.py
+++ b/deeplake/core/index_maintenance.py
@@ -299,7 +299,6 @@ def index_operation_dataset(self, dml_type, rowids):
             emb_tensor.create_vdb_index("hnsw_1", distance=distance)
     elif index_operation_type == INDEX_OP_TYPE.INCREMENTAL_INDEX:
         partition_count = index_partition_count(self)
-        print(f"Partition count: {partition_count}")
         if partition_count > 1:
             _incr_maintenance_vdb_indexes(
                 emb_tensor, rowids, dml_type, is_partitioned=True

--- a/deeplake/core/vectorstore/test_deeplake_vectorstore.py
+++ b/deeplake/core/vectorstore/test_deeplake_vectorstore.py
@@ -753,7 +753,6 @@ def test_delete(local_path, hub_cloud_dev_token):
     assert_vectorstore_structure(vector_store, 10)
 
     # delete the data in the dataset by id:
-    print(len(vector_store.dataset_handler.dataset))
     vector_store.delete(row_ids=[4, 8, 9])
     assert len(vector_store.dataset_handler.dataset) == NUMBER_OF_DATA - 3
 
@@ -1614,11 +1613,7 @@ def test_vdb_index_incr_maint_extend(local_path, capsys, hub_cloud_dev_token):
     query101 = ds.embedding[101].numpy()
     query102 = ds.embedding[102].numpy()
 
-    print(type(query1))
-    print(query1)
-
     s1 = ",".join(str(c) for c in query1)
-    print(s1)
     view1 = ds.query(
         f"select *  order by cosine_similarity(embedding ,array[{s1}]) DESC limit 1"
     )


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

This PR avoids an error when creating a view of a dataset group, like this:

```
ds = deeplake.empty("group_test", overwrite = True)
ds.create_tensor("group/test")
ds["group/test"].extend([np.random.rand(100,) for i in range(10000)])

ds.commit()

view = ds["group"][0:10]

view.save_view(id="firstdbf9474_positive_labels", optimize=True, num_workers=0)
```