### PR TITLE
Raise exception if a view to save's id already exists

### DIFF
--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -3663,13 +3663,14 @@ class Dataset:
         num_workers: int,
         scheduler: str,
         ignore_errors: bool,
+        overwrite: bool = False,
         **ds_args,
     ):
         """Saves this view at a given dataset path"""
         if os.path.abspath(path) == os.path.abspath(self.path):
             raise DatasetViewSavingError("Rewriting parent dataset is not allowed.")
         try:
-            vds = deeplake.empty(path, **ds_args)
+            vds = deeplake.empty(path, overwrite=overwrite, **ds_args)
         except Exception as e:
             raise DatasetViewSavingError from e
         info = self._get_view_info(id, message, copy)
@@ -3875,6 +3876,7 @@ class Dataset:
                     num_workers,
                     scheduler,
                     ignore_errors,
+                    overwrite,
                     **ds_args,
                 )
         if verbose and self.verbose:

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -3615,14 +3615,16 @@ class Dataset:
         num_workers: int,
         scheduler: str,
         ignore_errors: bool,
+        overwrite: bool = False,
     ):
-        """Saves this view under ".queries" sub directory of same storage."""
-        existing_views = self.get_views()
-        for v in existing_views:
-            if v.id == id:
-                raise DatasetViewSavingError(
-                    f"View with id {id} already exists. Use a different id or delete the existing view."
-                )
+        """Saves this view under ".queries" subdirectory of same storage."""
+        if not overwrite:
+            existing_views = self.get_views()
+            for v in existing_views:
+                if v.id == id:
+                    raise DatasetViewSavingError(
+                        f"View with id {id} already exists. Use a different id or delete the existing view."
+                    )
 
         info = self._get_view_info(id, message, copy)
         hash = info["id"]
@@ -3685,6 +3687,7 @@ class Dataset:
         scheduler: str = "threaded",
         verbose: bool = True,
         ignore_errors: bool = False,
+        overwrite: bool = False,
         **ds_args,
     ) -> str:
         """Saves a dataset view as a virtual dataset (VDS)
@@ -3760,6 +3763,7 @@ class Dataset:
             verbose,
             False,
             ignore_errors,
+            overwrite,
             **ds_args,
         )
 
@@ -3775,6 +3779,7 @@ class Dataset:
         verbose: bool = True,
         _ret_ds: bool = False,
         ignore_errors: bool = False,
+        overwrite: bool = False,
         **ds_args,
     ) -> Union[str, Any]:
         """Saves a dataset view as a virtual dataset (VDS)
@@ -3836,6 +3841,7 @@ class Dataset:
                                     num_workers,
                                     scheduler,
                                     ignore_errors,
+                                    overwrite,
                                 )
                         except ReadOnlyModeError as e:
                             raise ReadOnlyModeError(
@@ -3855,6 +3861,7 @@ class Dataset:
                         num_workers,
                         scheduler,
                         ignore_errors,
+                        overwrite,
                     )
             else:
                 vds = self._save_view_in_path(

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -3617,6 +3617,13 @@ class Dataset:
         ignore_errors: bool,
     ):
         """Saves this view under ".queries" sub directory of same storage."""
+        existing_views = self.get_views()
+        for v in existing_views:
+            if v.id == id:
+                raise DatasetViewSavingError(
+                    f"View with id {id} already exists. Use a different id or delete the existing view."
+                )
+
         info = self._get_view_info(id, message, copy)
         hash = info["id"]
         # creating sub-view of optimized view

--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -3723,6 +3723,7 @@ class Dataset:
             scheduler (str): The scheduler to be used for optimization. Supported values include: 'serial', 'threaded', and 'processed'. Only applicable if ``optimize=True``. Defaults to 'threaded'.
             verbose (bool): If ``True``, logs will be printed. Defaults to ``True``.
             ignore_errors (bool): Skip samples that cause errors while saving views. Only applicable if ``optimize=True``. Defaults to ``False``.
+            overwrite (bool): If true, any existing view with the same id is silently overwritten. If false, an exception is thrown if a view with the same the id exists. Defaults to ``False``.
             ds_args (dict): Additional args for creating VDS when path is specified. (See documentation for :func:`deeplake.dataset()`)
 
         Returns:
@@ -3798,6 +3799,7 @@ class Dataset:
             _ret_ds (bool): If ``True``, the VDS is retured as such without converting it to a view. If ``False``, the VDS path is returned.
                 Default False.
             ignore_errors (bool): Skip samples that cause errors while saving views. Only applicable if ``optimize=True``. Defaults to ``False``.
+            overwrite (bool): If true, any existing view with the same id is silently overwritten. If false, an exception is thrown if a view with the same the id exists. Defaults to ``False``.
             ds_args (dict): Additional args for creating VDS when path is specified. (See documentation for `deeplake.dataset()`)
 
         Returns:

--- a/deeplake/core/query/test/test_query.py
+++ b/deeplake/core/query/test/test_query.py
@@ -152,7 +152,11 @@ def test_sub_sample_view_save(optimize, idx_subscriptable, compressed_image_path
         view.save_view(optimize=optimize)
     ds.commit()
     ds.save_view(optimize=optimize, id=id)
-    view.save_view(optimize=optimize, id=id)  # test overwrite
+
+    with pytest.raises(DatasetViewSavingError):
+        ds.save_view(optimize=optimize, id=id)
+
+    view.save_view(optimize=optimize, id=id, overwrite=True)  # test overwrite
     assert len(ds.get_views()) == 1
     view2 = ds.get_views()[0].load()
     np.testing.assert_array_equal(view.x.numpy(), view2.x.numpy())


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

A script like this unexpectedly overwrites the existing view:

```
ds = deeplake.empty("debug_branch_view", overwrite=True)
ds.create_tensor("test")
ds.extend({"test": np.random.rand(100, 100, 3)})
ds.commit("first_commit")
view_1 = ds[0:10]
view_1.save_view(id = "view_id")

view_2 = ds[20:30]
view_2.save_view(id = "view_id")

print(ds.get_views())
print(len(ds.get_views()))
```

This PR change the 2nd save_view to raise an exception
