### PR TITLE
[WIP] Don't throw exceptions in getting the username out of the dataset.token

### DIFF
--- a/deeplake/core/dataset/dataset.py
+++ b/deeplake/core/dataset/dataset.py
@@ -353,7 +353,7 @@ class Dataset:
 
         try:
             return jwt.decode(self.token, options={"verify_signature": False})["id"]
-        except DecodeError:
+        except:
             return "public"
 
     @property

--- a/deeplake/core/tests/test_dataset.py
+++ b/deeplake/core/tests/test_dataset.py
@@ -3,6 +3,7 @@ import traceback
 
 import numpy as np
 import pytest
+import jwt
 
 import deeplake
 from deeplake.client.config import DEEPLAKE_AUTH_TOKEN
@@ -36,6 +37,16 @@ def test_token_and_username(hub_cloud_dev_token):
     )
     assert ds.token == "invalid_value"
     assert ds.username == "public"
+
+    # valid tokens that are formatted oddly come through as "public"
+    ds = Dataset(
+        token=jwt.encode({"x": "unused"}, None, algorithm="none"),
+        storage=LRUCache(
+            cache_storage=MemoryProvider(), cache_size=0, next_storage=MemoryProvider()
+        ),
+    )
+    assert ds.username == "public"
+
 
     # valid tokens come through correctly
     ds = Dataset(


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

If a token is invalid for any reason, always return a username of "public".

Currently we return a username of public for activeloop tokens that are malformed, but if it's a valid JWT token but missing the id field it throws a KeyError

This PR makes username return public if any problems happen in getting the id out.