### PR TITLE
Fixed updates.

### DIFF
--- a/cpp/deeplake_pg/pg_deeplake.cpp
+++ b/cpp/deeplake_pg/pg_deeplake.cpp
@@ -13,7 +13,6 @@ void index_info::create_deeplake_indexes()
 {
     auto ds = dataset();
     ASSERT(ds != nullptr);
-    ds->set_indexing_mode(deeplake::indexing_mode::always);
     bool index_created = false;
     for (auto& column_name : column_names_) {
         /// 'none' means hybrid index type
@@ -66,6 +65,10 @@ void index_info::create_deeplake_indexes()
                 elog(ERROR,
                      "Invalid index type '%s' for text column. Use 'inverted', 'bm25' or 'exact_text'",
                      deeplake_core::deeplake_index_type::to_string(index_type_).data());
+            }
+            // Set indexing mode to always for BM25 indexes only
+            if (index_type_ == deeplake_core::deeplake_index_type::type::bm25) {
+                ds->set_indexing_mode(deeplake::indexing_mode::always);
             }
             column.create_index(deeplake_core::index_type(deeplake_core::text_index_type(index_type_)));
             index_created = true;

--- a/postgres/tests/py_tests/test_rename_column_update_bug.py
+++ b/postgres/tests/py_tests/test_rename_column_update_bug.py
@@ -1,0 +1,188 @@
+"""
+Test UPDATE operations after ALTER TABLE RENAME COLUMN.
+
+This test isolates a known bug where UPDATE statements with WHERE clauses
+on TEXT columns fail after renaming a column.
+"""
+import pytest
+import asyncpg
+
+
+@pytest.mark.asyncio
+async def test_update_with_where_on_integer_after_rename(db_conn: asyncpg.Connection):
+    """
+    Test that UPDATE with WHERE on INTEGER columns works after RENAME COLUMN.
+    This should pass.
+    """
+    try:
+        await db_conn.execute("""
+            CREATE TABLE test_update_int (
+                id SERIAL PRIMARY KEY,
+                name TEXT,
+                email VARCHAR(255)
+            ) USING deeplake
+        """)
+
+        await db_conn.execute("""
+            INSERT INTO test_update_int (name, email) VALUES ('Alice', 'alice@example.com')
+        """)
+
+        await db_conn.execute("""
+            ALTER TABLE test_update_int RENAME COLUMN email TO email_address
+        """)
+
+        # UPDATE with WHERE on INTEGER column - should work
+        await db_conn.execute("""
+            UPDATE test_update_int SET email_address = 'new@example.com' WHERE id = 1
+        """)
+
+        row = await db_conn.fetchrow("SELECT * FROM test_update_int WHERE id = 1")
+        assert row is not None, "Row should exist"
+        assert row['email_address'] == 'new@example.com', \
+            f"Expected 'new@example.com', got '{row['email_address']}'"
+        assert row['id'] == 1, f"Expected id=1, got {row['id']}"
+        assert row['name'] == 'Alice', f"Expected 'Alice', got '{row['name']}'"
+
+        print("✓ Test passed: UPDATE with WHERE on INTEGER after RENAME works")
+
+    finally:
+        try:
+            await db_conn.execute("DROP TABLE IF EXISTS test_update_int CASCADE")
+        except:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_update_with_where_on_text_after_rename(db_conn: asyncpg.Connection):
+    """
+    Test that UPDATE with WHERE on TEXT columns fails after RENAME COLUMN.
+
+    Bug: UPDATE statements with WHERE clauses on TEXT columns after renaming
+    a column cause the id column to become NULL, resulting in:
+    ERROR: null value in column "id" violates not-null constraint
+    DETAIL: Failing row contains (null, Alice, new@example.com).
+    """
+    try:
+        await db_conn.execute("""
+            CREATE TABLE test_update_text (
+                id SERIAL PRIMARY KEY,
+                name TEXT,
+                email VARCHAR(255)
+            ) USING deeplake
+        """)
+
+        await db_conn.execute("""
+            INSERT INTO test_update_text (name, email) VALUES ('Alice', 'alice@example.com')
+        """)
+
+        await db_conn.execute("""
+            ALTER TABLE test_update_text RENAME COLUMN email TO email_address
+        """)
+
+        # UPDATE with WHERE on TEXT column - currently fails
+        await db_conn.execute("""
+            UPDATE test_update_text SET email_address = 'new@example.com' WHERE name = 'Alice'
+        """)
+
+        row = await db_conn.fetchrow("SELECT * FROM test_update_text WHERE name = 'Alice'")
+        assert row is not None, "Row should exist"
+        assert row['email_address'] == 'new@example.com', \
+            f"Expected 'new@example.com', got '{row['email_address']}'"
+        assert row['id'] == 1, f"Expected id=1, got {row['id']}"
+        assert row['name'] == 'Alice', f"Expected 'Alice', got '{row['name']}'"
+
+        print("✓ Test passed: UPDATE with WHERE on TEXT after RENAME works")
+
+    finally:
+        try:
+            await db_conn.execute("DROP TABLE IF EXISTS test_update_text CASCADE")
+        except:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_update_without_where_after_rename(db_conn: asyncpg.Connection):
+    """
+    Test that UPDATE without WHERE clause works after RENAME COLUMN.
+    This should pass.
+    """
+    try:
+        await db_conn.execute("""
+            CREATE TABLE test_update_no_where (
+                id SERIAL PRIMARY KEY,
+                name TEXT,
+                email VARCHAR(255)
+            ) USING deeplake
+        """)
+
+        await db_conn.execute("""
+            INSERT INTO test_update_no_where (name, email) VALUES ('Alice', 'alice@example.com')
+        """)
+
+        await db_conn.execute("""
+            ALTER TABLE test_update_no_where RENAME COLUMN email TO email_address
+        """)
+
+        # UPDATE without WHERE clause - should work
+        await db_conn.execute("""
+            UPDATE test_update_no_where SET email_address = 'new@example.com'
+        """)
+
+        row = await db_conn.fetchrow("SELECT * FROM test_update_no_where")
+        assert row is not None, "Row should exist"
+        assert row['email_address'] == 'new@example.com', \
+            f"Expected 'new@example.com', got '{row['email_address']}'"
+        assert row['id'] == 1, f"Expected id=1, got {row['id']}"
+        assert row['name'] == 'Alice', f"Expected 'Alice', got '{row['name']}'"
+
+        print("✓ Test passed: UPDATE without WHERE after RENAME works")
+
+    finally:
+        try:
+            await db_conn.execute("DROP TABLE IF EXISTS test_update_no_where CASCADE")
+        except:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_update_with_where_on_varchar_after_rename(db_conn: asyncpg.Connection):
+    """
+    Test that UPDATE with WHERE on VARCHAR columns also fails after RENAME COLUMN.
+    This verifies the bug affects VARCHAR (not just TEXT).
+    """
+    try:
+        await db_conn.execute("""
+            CREATE TABLE test_update_varchar (
+                id SERIAL PRIMARY KEY,
+                name TEXT,
+                email VARCHAR(255)
+            ) USING deeplake
+        """)
+
+        await db_conn.execute("""
+            INSERT INTO test_update_varchar (name, email) VALUES ('Alice', 'alice@example.com')
+        """)
+
+        await db_conn.execute("""
+            ALTER TABLE test_update_varchar RENAME COLUMN name TO full_name
+        """)
+
+        # UPDATE with WHERE on VARCHAR column - currently fails
+        await db_conn.execute("""
+            UPDATE test_update_varchar SET email = 'new@example.com' WHERE email = 'alice@example.com'
+        """)
+
+        row = await db_conn.fetchrow("SELECT * FROM test_update_varchar WHERE email = 'new@example.com'")
+        assert row is not None, "Row should exist"
+        assert row['email'] == 'new@example.com', \
+            f"Expected 'new@example.com', got '{row['email']}'"
+        assert row['id'] == 1, f"Expected id=1, got {row['id']}"
+        assert row['full_name'] == 'Alice', f"Expected 'Alice', got '{row['full_name']}'"
+
+        print("✓ Test passed: UPDATE with WHERE on VARCHAR after RENAME works")
+
+    finally:
+        try:
+            await db_conn.execute("DROP TABLE IF EXISTS test_update_varchar CASCADE")
+        except:
+            pass


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

<!--
A clear and concise description of the change being made.

The title should introduce what was/will be done
  - Titles show in release notes and search results, so make them useful
  - Be specific about what was fixed or changed
  - Imagine yourself looking for this PR in 6 months -- what will make it findable and valuable to future you?
  - Good Example: `Correctly apply passed S3 credentials when using VectorStore`
  - Bad Example: `Fixed creds issue`

The description gives the details on what was/will be done
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need to know and how the fix will affect them
- Describe how the code change addresses the problem
- Imagine yourself looking for this PR in 6 months -- what will make it findable and valuable to future you?
- Ensure private information is redacted.
-->

### Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

### Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have
-->

### Additional Context

<!--
Add any other context about the problem here.
-->
