### PR TITLE
Varchar 1 fix on parallel ingestion.

### DIFF
--- a/cpp/deeplake_pg/table_storage.cpp
+++ b/cpp/deeplake_pg/table_storage.cpp
@@ -258,7 +258,7 @@ void table_storage::save_table_metadata(const pg::table_data& table_data)
             pg::dl_catalog::column_meta col;
             col.table_id = table_id;
             col.column_name = NameStr(attr->attname);
-            col.pg_type = format_type_be(attr->atttypid);
+            col.pg_type = format_type_with_typemod(attr->atttypid, attr->atttypmod);
             col.nullable = !attr->attnotnull;
             col.position = i;
             columns.push_back(std::move(col));


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description

<!--
A clear and concise description of the change being made.

The title should introduce what was/will be done
  - Titles show in release notes and search results, so make them useful
  - Be specific about what was fixed or changed
  - Imagine yourself looking for this PR in 6 months -- what will make it findable and valuable to future you?
  - Good Example: `Correctly apply passed S3 credentials when using VectorStore`
  - Bad Example: `Fixed creds issue`

The description gives the details on what was/will be done
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need to know and how the fix will affect them
- Describe how the code change addresses the problem
- Imagine yourself looking for this PR in 6 months -- what will make it findable and valuable to future you?
- Ensure private information is redacted.
-->

### Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

### Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have
-->

### Additional Context

<!--
Add any other context about the problem here.
-->
