### PR TITLE
fix: wrong Dockerfile path in docs docker-compose.yaml

### DIFF
--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
     container_name: deeplake-docs
     build:
       context: ..
-      dockerfile: dockerfiles/Dockerfile
+      dockerfile: docs/Dockerfile
     ports:
       - '8000:8000'
     volumes:


### PR DESCRIPTION
## Summary
The `docker-compose.yaml` in the `docs/` directory references `dockerfiles/Dockerfile` as the build target, but no `dockerfiles/` directory exists in the repo. The actual Dockerfile lives at `docs/Dockerfile`, which is `docs/Dockerfile` relative to the build context (`..`, the repo root). Running `docker compose up` from the `docs/` directory fails immediately because Docker can't find the referenced file.

## How to reproduce
1. Clone the repo
2. `cd docs`
3. `docker compose up`
4. Error: `failed to solve: failed to read dockerfile: open dockerfiles/Dockerfile: no such file or directory`

## Test plan
- Run `docker compose up` from the `docs/` directory after the fix and confirm Docker finds and builds the Dockerfile successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration path for documentation service.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/deeplake/pull/3154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->